### PR TITLE
Update CI to latest patterns

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Prevent line ending conversion for test fixtures that are
+# cryptographically signed or contain binary data.
+key/testdata/** binary

--- a/.github/workflows/go-build-and-test.yaml
+++ b/.github/workflows/go-build-and-test.yaml
@@ -15,8 +15,11 @@ permissions: {}
 jobs:
   go-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
+      stable: ${{ steps.versions.outputs.GO_MINOR_VERSION_STABLE }}
+      previous: ${{ steps.versions.outputs.GO_MINOR_VERSION_PREVIOUS }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -24,24 +27,25 @@ jobs:
 
     - name: Determine Go versions
       id: versions
-      run: |
-        # Read the Go version from go.mod (e.g. "1.25" or "1.25.7")
-        MOD_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-        # Extract major.minor
-        MINOR=$(echo "$MOD_VERSION" | cut -d. -f2)
-        NEXT_MINOR=$((MINOR + 1))
-        # Saca las versiones en un array de JSON
-        echo "matrix=[\"1.${MINOR}\",\"1.${NEXT_MINOR}\"]" >> "$GITHUB_OUTPUT"
+      uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # main
 
   test:
     needs: go-versions
+    name: Go Tests (go ${{ matrix.go-version }}, ${{ matrix.os }})
     permissions:
       contents: read
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+        go-version:
+          - ${{ needs.go-versions.outputs.previous }}
+          - ${{ needs.go-versions.outputs.stable }}
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,16 +68,24 @@ jobs:
 
   e2e:
     needs: go-versions
+    name: E2E Tests (go ${{ matrix.go-version }}, ${{ matrix.os }})
     # Run on pushes, workflow_dispatch, and non-fork PRs (forks can't mint OIDC tokens)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write # needed for keyless signing
       contents: read
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+        go-version:
+          - ${{ needs.go-versions.outputs.previous }}
+          - ${{ needs.go-versions.outputs.stable }}
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,7 +13,23 @@ permissions:
   contents: read
 
 jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      stable: ${{ steps.versions.outputs.GO_MINOR_VERSION_STABLE }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Determine Go versions
+        id: versions
+        uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # main
+
   golangci:
+    needs: resolve-versions
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ needs.resolve-versions.outputs.stable }}
           check-latest: true
           cache: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,37 +17,33 @@ jobs:
       contents: write # needed to write releases 
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 1
           persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+          check-latest: true
 
       - name: Set tag output
         id: tag
         run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v3
-        with:
-          go-version-file: go.mod
-          cache: false  
-          check-latest: true
-  
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-
-      - name: Install bom
-        uses: kubernetes-sigs/release-actions/setup-bom@ab33480f30919958240822cfc29af8d9903f313b # v0.4.1
-
-      - name: Generate SBOM
-        shell: bash
-        run: |
-          bom generate --format=json -o /tmp/${{github.event.repository.owner}}-${{github.event.repository.name}}-${{ steps.tag.outputs.tag_name }}.spdx.json .
-
       - name: Publish Release
-        uses: kubernetes-sigs/release-actions/publish-release@ab33480f30919958240822cfc29af8d9903f313b # v0.4.1
+        uses: kubernetes-sigs/release-actions/publish-release@8753ea6bdadb814d779c6ec34eaca689dbfb492b # v0.4.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          assets: "/tmp/${{github.event.repository.owner}}-${{github.event.repository.name}}-${{ steps.tag.outputs.tag_name }}.spdx.json"
           sbom: false
+
+      - name: Generate SBOM
+        id: sbom
+        uses: carabiner-dev/actions/unpack/sbom@73e94b6ec4adbf65bb7b9f4ecec334dc6576553f # v1.1.6
+        with:
+          push-to-release: ${{ steps.tag.outputs.tag_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/bundle/verifier.go
+++ b/bundle/verifier.go
@@ -43,16 +43,26 @@ func WithSigstoreRootsData(data []byte) BundleOptsFunc {
 	}
 }
 
-// New creates a new verifier
+// New creates a new verifier. Initialization errors are logged to stderr
+// but not returned. Use NewWithError if you need to handle errors.
 func New(funcs ...BundleOptsFunc) Verifier {
+	v, err := NewWithError(funcs...)
+	if err != nil {
+		log.Default().Print(err)
+	}
+	return v
+}
+
+// NewWithError creates a new verifier and returns any initialization error.
+func NewWithError(funcs ...BundleOptsFunc) (Verifier, error) {
 	ret := &DefaultVerifier{}
 	for _, f := range funcs {
 		if err := f(ret); err != nil {
-			log.Default().Print(err)
+			return ret, err
 		}
 	}
 
-	return ret
+	return ret, nil
 }
 
 // VerifyCapable abstracts the verifier to mock

--- a/bundle/verifier_test.go
+++ b/bundle/verifier_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestVerify(t *testing.T) {
-	t.Parallel()
+	// Not parallel: subtests share the global TUF cache (~/.sigstore/root)
+	// and on Windows the atomic metadata rename fails with "Access is denied"
+	// when two goroutines access the same per-URL cache concurrently.
 	for _, tt := range []struct {
 		name         string
 		rootsPath    string
@@ -25,11 +27,15 @@ func TestVerify(t *testing.T) {
 		{"two-instances", "testdata/sigstore-roots.json", "testdata/public-good.sigstore.json", false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// Subtests must not run in parallel: they share the global
+			// TUF cache (~/.sigstore/root) and on Windows the atomic
+			// metadata rename fails with "Access is denied" when two
+			// goroutines access the same per-URL cache concurrently.
 			data, err := os.ReadFile(tt.rootsPath)
 			require.NoError(t, err)
 
-			verifier := New(WithSigstoreRootsData(data))
+			verifier, err := NewWithError(WithSigstoreRootsData(data))
+			require.NoError(t, err)
 
 			b, err := verifier.OpenBundle(tt.attestattion)
 			require.NoError(t, err)


### PR DESCRIPTION
This pull request introduces several improvements to the CI workflows, enhances error handling in the verifier initialization, and addresses concurrency issues in tests. The most significant changes include updating GitHub Actions workflows for better Go version management and multi-platform testing, improving the `Verifier` API to allow error handling, and making tests more robust and platform-compatible.

**CI/CD Workflow Improvements:**

* Updated `.github/workflows/go-build-and-test.yaml` and `.github/workflows/golangci-lint.yaml` to use a dedicated action for determining Go versions, supporting both stable and previous versions, and expanded testing to run on Linux, macOS, and Windows. Also improved permissions and matrix strategy for better coverage and reliability. [[1]](diffhunk://#diff-af9b960b730818c2a2c2ea6cc668715fcb5cfee8f37122d571e82e6963a5f86dR18-R48) [[2]](diffhunk://#diff-af9b960b730818c2a2c2ea6cc668715fcb5cfee8f37122d571e82e6963a5f86dR71-R88) [[3]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0R16-R32) [[4]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0L26-R42)
* Modernized the release workflow by updating action versions, improving code checkout, and moving SBOM generation to a dedicated action that uploads SBOMs to releases.

**Verifier Initialization and Error Handling:**

* Refactored the `New` function in `bundle/verifier.go` to log initialization errors instead of returning them, and introduced a new `NewWithError` function that returns any errors to the caller for improved error handling.

**Testing Reliability:**

* Updated `bundle/verifier_test.go` to avoid running tests in parallel due to shared global TUF cache, preventing failures on Windows and improving test reliability across platforms. Also switched tests to use `NewWithError` for explicit error checking. [[1]](diffhunk://#diff-8405c31782097fca1564db0080d33798cfcdb6221b675c85bdef5d78d82d41a0L16-R18) [[2]](diffhunk://#diff-8405c31782097fca1564db0080d33798cfcdb6221b675c85bdef5d78d82d41a0L28-R38)

**Repository Management:**

* Added a `.gitattributes` rule to prevent line ending conversion for test fixtures containing binary or cryptographically signed data.