### PR TITLE
Record GPG subkey fingerprints

### DIFF
--- a/dsse/verifier.go
+++ b/dsse/verifier.go
@@ -83,7 +83,7 @@ func (dv *DefaultVerifier) RunVerification(
 	for _, sig := range env.GetSignatures() {
 		for i, k := range publicKeys {
 			provider := providers[i]
-			_, isGPG := provider.(*key.GPGPublic)
+			gpgProvider, isGPG := provider.(*key.GPGPublic)
 			go func() {
 				var (
 					pass bool
@@ -98,8 +98,16 @@ func (dv *DefaultVerifier) RunVerification(
 					pass, err = kv.VerifyDigest(k, digests[k.HashType], sig.GetSig())
 				}
 				if err == nil && pass {
+					matched := k
+					if isGPG {
+						if fp, ferr := gpgProvider.SigningKeyFingerprint(sig.GetSig()); ferr == nil {
+							clone := *k
+							clone.SigningKeyFingerprint = fp
+							matched = &clone
+						}
+					}
 					mutex.Lock()
-					matchedKeys = append(matchedKeys, k)
+					matchedKeys = append(matchedKeys, matched)
 					mutex.Unlock()
 				}
 				t.Done(err)

--- a/dsse/verifier_test.go
+++ b/dsse/verifier_test.go
@@ -170,4 +170,15 @@ func TestRunVerificationGPG(t *testing.T) {
 	require.NotNil(t, res)
 	require.True(t, res.Verified)
 	require.Len(t, res.Keys, 1)
+
+	// The fixture key is a real-world GPG key with a certify-only primary
+	// and a dedicated signing subkey — the signature was produced by the
+	// subkey, so SigningKeyFingerprint must name the subkey (not the primary
+	// that ID() exposes).
+	const (
+		primaryFingerprint = "5270DFC517AD50957EDA0CFDBE1B8E71C9A0F3B2"
+		signingSubkeyFP    = "04B44C056663906446B77A6D89F11DC191AA7042"
+	)
+	require.Equal(t, primaryFingerprint, res.Keys[0].ID())
+	require.Equal(t, signingSubkeyFP, res.Keys[0].SigningKeyFingerprint)
 }

--- a/key/gpg.go
+++ b/key/gpg.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	gpgecdsa "github.com/ProtonMail/go-crypto/openpgp/ecdsa"
 	gpgeddsa "github.com/ProtonMail/go-crypto/openpgp/eddsa"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 // GPGPublic wraps an OpenPGP entity and provides access to its public key material.
@@ -159,6 +161,74 @@ func (g *GPGPublic) SerializeBinary(w io.Writer) error {
 // Entity returns the underlying openpgp.Entity.
 func (g *GPGPublic) Entity() *openpgp.Entity {
 	return g.entity
+}
+
+// SigningKeyFingerprint parses the OpenPGP signature packet and returns the
+// hex-encoded fingerprint of the key within this entity that produced the
+// signature.
+//
+// When the signature was made by a subkey, this method returns the subkey's
+// fingerprint, which is different from Fingerprint() which always returns the
+// primary key's fingerprint.
+func (g *GPGPublic) SigningKeyFingerprint(signature []byte) (string, error) {
+	// Parse the signature packet
+	sig, err := parseSignaturePacket(signature)
+	if err != nil {
+		return "", fmt.Errorf("parsing signature packet: %w", err)
+	}
+
+	if len(sig.IssuerFingerprint) > 0 {
+		if bytes.Equal(sig.IssuerFingerprint, g.entity.PrimaryKey.Fingerprint) {
+			return strings.ToUpper(hex.EncodeToString(g.entity.PrimaryKey.Fingerprint)), nil
+		}
+		for _, sk := range g.entity.Subkeys {
+			if sk.PublicKey != nil && bytes.Equal(sig.IssuerFingerprint, sk.PublicKey.Fingerprint) {
+				return strings.ToUpper(hex.EncodeToString(sk.PublicKey.Fingerprint)), nil
+			}
+		}
+		return "", fmt.Errorf("signature issuer fingerprint %x not found in entity", sig.IssuerFingerprint)
+	}
+
+	if sig.IssuerKeyId != nil {
+		if g.entity.PrimaryKey.KeyId == *sig.IssuerKeyId {
+			return strings.ToUpper(hex.EncodeToString(g.entity.PrimaryKey.Fingerprint)), nil
+		}
+		for _, sk := range g.entity.Subkeys {
+			if sk.PublicKey != nil && sk.PublicKey.KeyId == *sig.IssuerKeyId {
+				return strings.ToUpper(hex.EncodeToString(sk.PublicKey.Fingerprint)), nil
+			}
+		}
+		return "", fmt.Errorf("signature issuer key id %016X not found in entity", *sig.IssuerKeyId)
+	}
+
+	return "", errors.New("signature has no issuer identifier")
+}
+
+// parseSignaturePacket extracts the first Signature packet from raw bytes,
+// handling both ASCII-armored and binary OpenPGP encodings.
+func parseSignaturePacket(data []byte) (*packet.Signature, error) {
+	var r io.Reader = bytes.NewReader(data)
+	if isOpenPGPArmored(data) {
+		block, err := armor.Decode(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("decoding ASCII armor: %w", err)
+		}
+		r = block.Body
+	}
+
+	pr := packet.NewReader(r)
+	for {
+		p, err := pr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("no signature packet found")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading packet: %w", err)
+		}
+		if sig, ok := p.(*packet.Signature); ok {
+			return sig, nil
+		}
+	}
 }
 
 // underlyingKeyInfo returns the scheme and hash for the signing key.

--- a/key/gpg_test.go
+++ b/key/gpg_test.go
@@ -9,7 +9,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"encoding/hex"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -629,6 +631,62 @@ func TestCryptoKeyToTypeSchemeHash(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported key type")
 	})
+}
+
+// TestGPG_SigningKeyFingerprint_Subkey creates an entity with an explicit
+// signing subkey, produces an OpenPGP detached signature (which picks the
+// subkey via Entity.SigningKey), and asserts SigningKeyFingerprint returns
+// the subkey's fingerprint rather than the primary's.
+func TestGPG_SigningKeyFingerprint_Subkey(t *testing.T) {
+	t.Parallel()
+	entity := generateTestEntity(t, "Subkey Sign", "subkey@example.com", &packet.Config{
+		Algorithm: packet.PubKeyAlgoEdDSA,
+		Curve:     packet.Curve25519,
+	})
+	require.NoError(t, entity.AddSigningSubkey(&packet.Config{
+		Algorithm: packet.PubKeyAlgoEdDSA,
+		Curve:     packet.Curve25519,
+	}))
+
+	message := []byte("signed with an explicit subkey")
+	var sigBuf bytes.Buffer
+	require.NoError(t, openpgp.DetachSign(&sigBuf, entity, bytes.NewReader(message), nil))
+
+	gpgPub := newGPGPublic(entity)
+	fp, err := gpgPub.SigningKeyFingerprint(sigBuf.Bytes())
+	require.NoError(t, err)
+	require.NotEqual(t, gpgPub.Fingerprint(), fp, "signature should be attributed to the subkey, not the primary")
+
+	found := false
+	for _, sk := range entity.Subkeys {
+		if strings.EqualFold(fp, hex.EncodeToString(sk.PublicKey.Fingerprint)) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "fingerprint %s not found among subkeys", fp)
+}
+
+// TestGPG_SigningKeyFingerprint_Primary covers the case where the signature
+// is made directly by the primary key (no signing subkey): the method should
+// return the primary fingerprint and equal Fingerprint().
+func TestGPG_SigningKeyFingerprint_Primary(t *testing.T) {
+	t.Parallel()
+	entity := generateTestEntity(t, "Primary Sign", "primary@example.com", &packet.Config{
+		Algorithm: packet.PubKeyAlgoRSA,
+		RSABits:   2048,
+	})
+	// Strip subkeys so the primary is the only signing candidate.
+	entity.Subkeys = nil
+
+	message := []byte("signed with the primary key")
+	var sigBuf bytes.Buffer
+	require.NoError(t, openpgp.DetachSign(&sigBuf, entity, bytes.NewReader(message), nil))
+
+	gpgPub := newGPGPublic(entity)
+	fp, err := gpgPub.SigningKeyFingerprint(sigBuf.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, gpgPub.Fingerprint(), fp)
 }
 
 // TestGPG_FixtureSignVerify loads the pre-generated GPG key and signature

--- a/key/public.go
+++ b/key/public.go
@@ -62,6 +62,18 @@ type Public struct {
 	NotBefore *time.Time `json:"not_before"`
 	NotAfter  *time.Time `json:"not_after"`
 
+	// SigningKeyFingerprint is the fingerprint of the specific key that
+	// produced a verified signature.
+	// This is meant for GPG entities as it may differ from ID(). When a
+	// signature was made with a subkey:
+	//
+	//  - ID() returns the primary (identity) fingerprint
+	//  - This field returns the actual signer key.
+	//
+	// Only populated on entries in VerificationResult.Keys after a
+	// successful verification. It is emptu on general-purpose Public keys.
+	SigningKeyFingerprint string `json:"signing_key_fingerprint,omitempty"`
+
 	// overrideID, when set, is returned by ID() instead of computing
 	// an identifier from the key material. This is used to preserve
 	// the GPG fingerprint when converting from GPGPublic.


### PR DESCRIPTION
This PR adds support for capturing the subkey fingerprint when verifying a DSSE envelope signed with a subkey.