### PR TITLE
Add SPIFFE credentials provider

### DIFF
--- a/bundle/bundlefakes/fake_credential_provider.go
+++ b/bundle/bundlefakes/fake_credential_provider.go
@@ -3,6 +3,7 @@ package bundlefakes
 
 import (
 	"context"
+	"crypto/x509"
 	"sync"
 
 	"github.com/carabiner-dev/signer/bundle"
@@ -21,6 +22,16 @@ type FakeCredentialProvider struct {
 	certificateProviderReturnsOnCall map[int]struct {
 		result1 sign.CertificateProvider
 		result2 *sign.CertificateProviderOptions
+	}
+	IntermediatesStub        func() []*x509.Certificate
+	intermediatesMutex       sync.RWMutex
+	intermediatesArgsForCall []struct {
+	}
+	intermediatesReturns struct {
+		result1 []*x509.Certificate
+	}
+	intermediatesReturnsOnCall map[int]struct {
+		result1 []*x509.Certificate
 	}
 	KeypairStub        func() sign.Keypair
 	keypairMutex       sync.RWMutex
@@ -101,6 +112,59 @@ func (fake *FakeCredentialProvider) CertificateProviderReturnsOnCall(i int, resu
 		result1 sign.CertificateProvider
 		result2 *sign.CertificateProviderOptions
 	}{result1, result2}
+}
+
+func (fake *FakeCredentialProvider) Intermediates() []*x509.Certificate {
+	fake.intermediatesMutex.Lock()
+	ret, specificReturn := fake.intermediatesReturnsOnCall[len(fake.intermediatesArgsForCall)]
+	fake.intermediatesArgsForCall = append(fake.intermediatesArgsForCall, struct {
+	}{})
+	stub := fake.IntermediatesStub
+	fakeReturns := fake.intermediatesReturns
+	fake.recordInvocation("Intermediates", []interface{}{})
+	fake.intermediatesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeCredentialProvider) IntermediatesCallCount() int {
+	fake.intermediatesMutex.RLock()
+	defer fake.intermediatesMutex.RUnlock()
+	return len(fake.intermediatesArgsForCall)
+}
+
+func (fake *FakeCredentialProvider) IntermediatesCalls(stub func() []*x509.Certificate) {
+	fake.intermediatesMutex.Lock()
+	defer fake.intermediatesMutex.Unlock()
+	fake.IntermediatesStub = stub
+}
+
+func (fake *FakeCredentialProvider) IntermediatesReturns(result1 []*x509.Certificate) {
+	fake.intermediatesMutex.Lock()
+	defer fake.intermediatesMutex.Unlock()
+	fake.IntermediatesStub = nil
+	fake.intermediatesReturns = struct {
+		result1 []*x509.Certificate
+	}{result1}
+}
+
+func (fake *FakeCredentialProvider) IntermediatesReturnsOnCall(i int, result1 []*x509.Certificate) {
+	fake.intermediatesMutex.Lock()
+	defer fake.intermediatesMutex.Unlock()
+	fake.IntermediatesStub = nil
+	if fake.intermediatesReturnsOnCall == nil {
+		fake.intermediatesReturnsOnCall = make(map[int]struct {
+			result1 []*x509.Certificate
+		})
+	}
+	fake.intermediatesReturnsOnCall[i] = struct {
+		result1 []*x509.Certificate
+	}{result1}
 }
 
 func (fake *FakeCredentialProvider) Keypair() sign.Keypair {

--- a/bundle/credential_provider.go
+++ b/bundle/credential_provider.go
@@ -7,6 +7,7 @@ package bundle
 
 import (
 	"context"
+	"crypto/x509"
 
 	"github.com/sigstore/sigstore-go/pkg/sign"
 )
@@ -28,4 +29,15 @@ type CredentialProvider interface {
 	// populate VerificationMaterial, together with any provider-specific
 	// options (e.g. an OIDC ID token for Fulcio).
 	CertificateProvider() (sign.CertificateProvider, *sign.CertificateProviderOptions)
+
+	// Intermediates returns the certificates between the leaf and the trust
+	// anchor, in order from leaf-adjacent to root-adjacent. The root itself
+	// must NOT be included — verifiers supply it out-of-band.
+	//
+	// Returns nil when there are no intermediates to embed (the sigstore
+	// case, where the chain is reconstructed from TUF at verify time). When
+	// the return value is non-empty, the outer Signer rewrites the bundle's
+	// VerificationMaterial to carry [leaf, ...intermediates] so the verifier
+	// can build a path to its pinned trust anchor.
+	Intermediates() []*x509.Certificate
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sigstore/sigstore-go v1.1.4
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
+	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/stretchr/testify v1.11.1
 	github.com/theupdateframework/go-tuf/v2 v2.4.1
 	golang.org/x/term v0.42.0
@@ -21,6 +22,7 @@ require (
 )
 
 require (
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
@@ -318,6 +320,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/signer.go
+++ b/signer.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/sign"
@@ -153,6 +155,9 @@ func (s *Signer) SignStatement(data []byte, funcs ...options.SignOptFn) (*sbundl
 	if err != nil {
 		return nil, fmt.Errorf("singing statement: %w", err)
 	}
+	if err := s.attachIntermediates(bndl); err != nil {
+		return nil, fmt.Errorf("attaching intermediates: %w", err)
+	}
 	return &sbundle.Bundle{
 		Bundle: bndl,
 	}, nil
@@ -181,9 +186,51 @@ func (s *Signer) SignMessage(data []byte, funcs ...options.SignOptFn) (*sbundle.
 	if err != nil {
 		return nil, fmt.Errorf("singing statement: %w", err)
 	}
+	if err := s.attachIntermediates(bndl); err != nil {
+		return nil, fmt.Errorf("attaching intermediates: %w", err)
+	}
 	return &sbundle.Bundle{
 		Bundle: bndl,
 	}, nil
+}
+
+// attachIntermediates rewrites the bundle's VerificationMaterial to carry
+// [leaf, ...intermediates] when the credential provider exposes intermediates.
+// When the provider returns an empty chain (the sigstore case) the bundle is
+// left untouched. Called after SignBundle so the leaf DER is already present
+// in VerificationMaterial.Content.
+func (s *Signer) attachIntermediates(bndl *protobundle.Bundle) error {
+	if s.Credentials == nil {
+		return nil
+	}
+	ints := s.Credentials.Intermediates()
+	if len(ints) == 0 {
+		return nil
+	}
+	if bndl.GetVerificationMaterial() == nil {
+		return errors.New("bundle has no verification material")
+	}
+	leaf, ok := bndl.GetVerificationMaterial().GetContent().(*protobundle.VerificationMaterial_Certificate)
+	if !ok || leaf.Certificate == nil {
+		// Already a chain, a public key, or nothing — leave as-is.
+		return nil
+	}
+
+	chain := &protocommon.X509CertificateChain{
+		Certificates: make([]*protocommon.X509Certificate, 0, 1+len(ints)),
+	}
+	chain.Certificates = append(chain.Certificates, &protocommon.X509Certificate{
+		RawBytes: leaf.Certificate.GetRawBytes(),
+	})
+	for _, c := range ints {
+		chain.Certificates = append(chain.Certificates, &protocommon.X509Certificate{
+			RawBytes: c.Raw,
+		})
+	}
+	bndl.VerificationMaterial.Content = &protobundle.VerificationMaterial_X509CertificateChain{
+		X509CertificateChain: chain,
+	}
+	return nil
 }
 
 // SignStatementToDSSE is a convenience method around SignMessageToDSSE that

--- a/signer_test.go
+++ b/signer_test.go
@@ -4,10 +4,19 @@
 package signer
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
+	"math/big"
 	"os"
 	"testing"
+	"time"
 
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/require"
@@ -286,6 +295,115 @@ func TestSigningStateReuse(t *testing.T) {
 	// But credential preparation and bundle options wiring only happen once
 	require.Equal(t, 1, fakeCredentials.PrepareCallCount())
 	require.Equal(t, 1, fakeBundleSigner.BuildBundleOptionsCallCount())
+}
+
+// mintTestCert mints a self-signed ECDSA cert for tests that need a
+// DER-encoded x509.Certificate.
+func mintTestCert(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// TestSignStatementAttachesIntermediates exercises the bundle post-processing
+// path: when the credential provider returns intermediates, the outer Signer
+// rewrites the bundle's VerificationMaterial from Certificate (leaf-only) to
+// X509CertificateChain carrying [leaf, ...intermediates].
+func TestSignStatementAttachesIntermediates(t *testing.T) {
+	t.Parallel()
+
+	statementData, err := os.ReadFile("bundle/testdata/statement.json")
+	require.NoError(t, err)
+
+	leaf := mintTestCert(t, "leaf")
+	intermediate := mintTestCert(t, "intermediate")
+
+	// Fake SignBundle returns a leaf-only bundle — mirrors what sigstore-go's
+	// sign.Bundle produces via VerificationMaterial_Certificate.
+	fakeBundleSigner := &bundlefakes.FakeSigner{}
+	fakeBundleSigner.SignBundleReturns(&protobundle.Bundle{
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_Certificate{
+				Certificate: &protocommon.X509Certificate{RawBytes: leaf.Raw},
+			},
+		},
+	}, nil)
+
+	fakeCredentials := &bundlefakes.FakeCredentialProvider{}
+	fakeCredentials.IntermediatesReturns([]*x509.Certificate{intermediate})
+
+	opts := options.DefaultSigner
+	require.NoError(t, opts.Validate())
+
+	s := &Signer{
+		Options:      opts,
+		Credentials:  fakeCredentials,
+		bundleSigner: fakeBundleSigner,
+	}
+
+	bndl, err := s.SignStatement(statementData)
+	require.NoError(t, err)
+	require.NotNil(t, bndl)
+
+	chainContent, ok := bndl.GetVerificationMaterial().GetContent().(*protobundle.VerificationMaterial_X509CertificateChain)
+	require.True(t, ok, "expected X509CertificateChain content, got %T", bndl.GetVerificationMaterial().GetContent())
+	chainCerts := chainContent.X509CertificateChain.GetCertificates()
+	require.Len(t, chainCerts, 2)
+	require.Equal(t, leaf.Raw, chainCerts[0].GetRawBytes())
+	require.Equal(t, intermediate.Raw, chainCerts[1].GetRawBytes())
+}
+
+// TestSignStatementLeavesLeafOnlyBundleUntouched verifies the sigstore path:
+// when the credential provider reports no intermediates, the bundle's
+// leaf-only VerificationMaterial is preserved.
+func TestSignStatementLeavesLeafOnlyBundleUntouched(t *testing.T) {
+	t.Parallel()
+
+	statementData, err := os.ReadFile("bundle/testdata/statement.json")
+	require.NoError(t, err)
+
+	leaf := mintTestCert(t, "leaf")
+
+	fakeBundleSigner := &bundlefakes.FakeSigner{}
+	fakeBundleSigner.SignBundleReturns(&protobundle.Bundle{
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_Certificate{
+				Certificate: &protocommon.X509Certificate{RawBytes: leaf.Raw},
+			},
+		},
+	}, nil)
+
+	fakeCredentials := &bundlefakes.FakeCredentialProvider{}
+	// Intermediates defaults to returning nil.
+
+	opts := options.DefaultSigner
+	require.NoError(t, opts.Validate())
+
+	s := &Signer{
+		Options:      opts,
+		Credentials:  fakeCredentials,
+		bundleSigner: fakeBundleSigner,
+	}
+
+	bndl, err := s.SignStatement(statementData)
+	require.NoError(t, err)
+
+	leafContent, ok := bndl.GetVerificationMaterial().GetContent().(*protobundle.VerificationMaterial_Certificate)
+	require.True(t, ok, "expected Certificate content, got %T", bndl.GetVerificationMaterial().GetContent())
+	require.Equal(t, leaf.Raw, leafContent.Certificate.GetRawBytes())
 }
 
 // Compile-time check: bundle.CredentialProvider and bundle.Signer are

--- a/sigstore/credential_provider.go
+++ b/sigstore/credential_provider.go
@@ -126,6 +126,11 @@ func (p *CredentialProvider) CertificateProvider() (sign.CertificateProvider, *s
 	return p.cp, opts
 }
 
+// Intermediates returns nil. The Fulcio chain is reconstructed at verify
+// time from the sigstore TUF root, so no intermediates are embedded in the
+// bundle's VerificationMaterial.
+func (p *CredentialProvider) Intermediates() []*x509.Certificate { return nil }
+
 // runAmbientSTS iterates over the configured STS providers until it gets a token
 func (p *CredentialProvider) runAmbientSTS(ctx context.Context) error {
 	for k, provider := range sts.DefaultProviders {

--- a/spiffe/cert_provider.go
+++ b/spiffe/cert_provider.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package spiffe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+)
+
+var _ sign.CertificateProvider = (*svidCertProvider)(nil)
+
+// svidCertProvider returns the current SVID leaf certificate as DER on each
+// call. Intermediates are intentionally omitted in this phase — they will be
+// embedded via VerificationMaterial.X509CertificateChain in a follow-up once
+// the outer Signer post-processes the bundle.
+type svidCertProvider struct {
+	source x509svid.Source
+}
+
+func (p *svidCertProvider) GetCertificate(_ context.Context, _ sign.Keypair, _ *sign.CertificateProviderOptions) ([]byte, error) {
+	svid, err := p.source.GetX509SVID()
+	if err != nil {
+		return nil, fmt.Errorf("fetching svid: %w", err)
+	}
+	if len(svid.Certificates) == 0 {
+		return nil, errors.New("svid has no certificates")
+	}
+	return svid.Certificates[0].Raw, nil
+}

--- a/spiffe/credential_provider.go
+++ b/spiffe/credential_provider.go
@@ -5,6 +5,7 @@ package spiffe
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 
 	"github.com/sigstore/sigstore-go/pkg/sign"
@@ -98,6 +99,23 @@ func (p *CredentialProvider) Keypair() sign.Keypair { return p.keypair }
 // No provider options are required for the SPIFFE path.
 func (p *CredentialProvider) CertificateProvider() (sign.CertificateProvider, *sign.CertificateProviderOptions) {
 	return p.certProv, nil
+}
+
+// Intermediates returns the certs between the SVID leaf and the trust domain
+// root, taken from the current SVID. The trust anchor itself is NOT
+// included — verifiers pin it out-of-band.
+func (p *CredentialProvider) Intermediates() []*x509.Certificate {
+	if p.Source == nil {
+		return nil
+	}
+	svid, err := p.Source.GetX509SVID()
+	if err != nil || len(svid.Certificates) <= 1 {
+		return nil
+	}
+	// Copy so callers can't mutate the SVID's slice.
+	out := make([]*x509.Certificate, len(svid.Certificates)-1)
+	copy(out, svid.Certificates[1:])
+	return out
 }
 
 // Close releases any workloadapi.X509Source opened by Prepare. Sources

--- a/spiffe/credential_provider.go
+++ b/spiffe/credential_provider.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package spiffe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+// Options configures a SPIFFE CredentialProvider.
+type Options struct {
+	// SocketPath is the Workload API endpoint (typically "unix:///...").
+	// When empty, go-spiffe reads SPIFFE_ENDPOINT_SOCKET from the environment.
+	SocketPath string
+
+	// ExpectedTrustDomain, when non-zero, asserts that the issued SVID
+	// belongs to this trust domain. Mismatch causes Prepare to fail.
+	ExpectedTrustDomain spiffeid.TrustDomain
+}
+
+// CredentialProvider implements bundle.CredentialProvider using X.509-SVIDs
+// from the SPIFFE Workload API. The Workload API stream is opened at Prepare
+// time and rotates automatically; callers should invoke Close when done.
+type CredentialProvider struct {
+	Options Options
+
+	// Source is the SVID source used by the keypair and cert provider. When
+	// nil, Prepare opens a workloadapi.X509Source against Options.SocketPath.
+	// Tests inject a fake source to exercise the provider without a running
+	// Workload API.
+	Source x509svid.Source
+
+	// closer, when set, is invoked by Close to release resources owned by
+	// the provider (e.g. the workloadapi.X509Source started in Prepare).
+	closer   func() error
+	keypair  sign.Keypair
+	certProv sign.CertificateProvider
+	prepared bool
+}
+
+// NewCredentialProvider creates a SPIFFE CredentialProvider with the given
+// options.
+func NewCredentialProvider(opts Options) *CredentialProvider {
+	return &CredentialProvider{Options: opts}
+}
+
+// Prepare connects to the Workload API (if no Source was injected) and
+// verifies that an SVID is available. Subsequent calls are no-ops.
+func (p *CredentialProvider) Prepare(ctx context.Context) error {
+	if p.prepared {
+		return nil
+	}
+
+	if p.Source == nil {
+		var clientOpts []workloadapi.ClientOption
+		if p.Options.SocketPath != "" {
+			clientOpts = append(clientOpts, workloadapi.WithAddr(p.Options.SocketPath))
+		}
+		src, err := workloadapi.NewX509Source(ctx, workloadapi.WithClientOptions(clientOpts...))
+		if err != nil {
+			return fmt.Errorf("connecting to spiffe workload api: %w", err)
+		}
+		p.Source = src
+		p.closer = src.Close
+	}
+
+	// Fetch once so Prepare fails fast if the agent isn't handing out an SVID.
+	svid, err := p.Source.GetX509SVID()
+	if err != nil {
+		p.Close() //nolint:errcheck,gosec // best-effort cleanup; the original error is the one that matters
+		return fmt.Errorf("fetching initial svid: %w", err)
+	}
+
+	if !p.Options.ExpectedTrustDomain.IsZero() && svid.ID.TrustDomain() != p.Options.ExpectedTrustDomain {
+		p.Close() //nolint:errcheck,gosec // best-effort cleanup; the original error is the one that matters
+		return fmt.Errorf(
+			"svid trust domain %q does not match expected %q",
+			svid.ID.TrustDomain(), p.Options.ExpectedTrustDomain,
+		)
+	}
+
+	p.keypair = &svidKeypair{source: p.Source}
+	p.certProv = &svidCertProvider{source: p.Source}
+	p.prepared = true
+	return nil
+}
+
+// Keypair returns the sign.Keypair backed by the SVID private key.
+func (p *CredentialProvider) Keypair() sign.Keypair { return p.keypair }
+
+// CertificateProvider returns the provider that yields the current SVID leaf.
+// No provider options are required for the SPIFFE path.
+func (p *CredentialProvider) CertificateProvider() (sign.CertificateProvider, *sign.CertificateProviderOptions) {
+	return p.certProv, nil
+}
+
+// Close releases any workloadapi.X509Source opened by Prepare. Sources
+// injected by callers are not closed here — the caller owns their lifecycle.
+func (p *CredentialProvider) Close() error {
+	if p.closer == nil {
+		return nil
+	}
+	err := p.closer()
+	p.closer = nil
+	return err
+}

--- a/spiffe/credential_provider_test.go
+++ b/spiffe/credential_provider_test.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package spiffe
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSource implements x509svid.Source for tests.
+type fakeSource struct {
+	svid *x509svid.SVID
+	err  error
+}
+
+func (f *fakeSource) GetX509SVID() (*x509svid.SVID, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.svid, nil
+}
+
+// mintTestSVID creates a self-signed ECDSA-P256 SVID under the given trust
+// domain (defaults to "example.org"), with SPIFFE path "/workload". Good
+// enough for unit tests — the chain doesn't go back to any real trust bundle.
+func mintTestSVID(t *testing.T, td string) *x509svid.SVID {
+	t.Helper()
+
+	if td == "" {
+		td = "example.org"
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	id := spiffeid.RequireFromPath(spiffeid.RequireTrustDomainFromString(td), "/workload")
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-svid"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		URIs:                  []*url.URL{id.URL()},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return &x509svid.SVID{
+		ID:           id,
+		Certificates: []*x509.Certificate{cert},
+		PrivateKey:   key,
+	}
+}
+
+func TestCredentialProviderLeafOnly(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+
+	p := &CredentialProvider{Source: &fakeSource{svid: svid}}
+	require.NoError(t, p.Prepare(context.Background()))
+
+	kp := p.Keypair()
+	require.NotNil(t, kp)
+
+	cp, opts := p.CertificateProvider()
+	require.NotNil(t, cp)
+	require.Nil(t, opts)
+
+	certDER, err := cp.GetCertificate(context.Background(), kp, nil)
+	require.NoError(t, err)
+	require.Equal(t, svid.Certificates[0].Raw, certDER)
+}
+
+func TestPrepareFailsWhenSourceErrors(t *testing.T) {
+	t.Parallel()
+	p := &CredentialProvider{Source: &fakeSource{err: errors.New("no svid available")}}
+	err := p.Prepare(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fetching initial svid")
+}
+
+func TestPrepareRejectsWrongTrustDomain(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "other.example")
+	expected := spiffeid.RequireTrustDomainFromString("example.org")
+
+	p := &CredentialProvider{
+		Options: Options{ExpectedTrustDomain: expected},
+		Source:  &fakeSource{svid: svid},
+	}
+	err := p.Prepare(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match expected")
+}
+
+func TestPrepareAcceptsMatchingTrustDomain(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+
+	p := &CredentialProvider{
+		Options: Options{ExpectedTrustDomain: spiffeid.RequireTrustDomainFromString("example.org")},
+		Source:  &fakeSource{svid: svid},
+	}
+	require.NoError(t, p.Prepare(context.Background()))
+}
+
+func TestPrepareIsIdempotent(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+
+	p := &CredentialProvider{Source: &fakeSource{svid: svid}}
+	require.NoError(t, p.Prepare(context.Background()))
+	require.NoError(t, p.Prepare(context.Background()))
+}
+
+func TestSignDataVerifiesAgainstSVIDPublicKey(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+	kp := &svidKeypair{source: &fakeSource{svid: svid}}
+
+	payload := []byte("some payload bytes")
+	sig, digest, err := kp.SignData(context.Background(), payload)
+	require.NoError(t, err)
+
+	pub, ok := svid.Certificates[0].PublicKey.(*ecdsa.PublicKey)
+	require.True(t, ok, "test svid should have ECDSA public key")
+	require.True(t, ecdsa.VerifyASN1(pub, digest, sig),
+		"signature should verify against the SVID public key")
+}
+
+func TestGetHintStableForSameSVID(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+	kp := &svidKeypair{source: &fakeSource{svid: svid}}
+
+	h1 := kp.GetHint()
+	h2 := kp.GetHint()
+	require.Equal(t, h1, h2)
+	require.NotEmpty(t, h1)
+}
+
+func TestKeypairAccessorsForECDSAP256(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+	kp := &svidKeypair{source: &fakeSource{svid: svid}}
+
+	require.Equal(t, "ECDSA", kp.GetKeyAlgorithm())
+
+	pem, err := kp.GetPublicKeyPem()
+	require.NoError(t, err)
+	require.Contains(t, pem, "BEGIN PUBLIC KEY")
+	require.Contains(t, pem, "END PUBLIC KEY")
+
+	require.NotNil(t, kp.GetPublicKey())
+}

--- a/spiffe/credential_provider_test.go
+++ b/spiffe/credential_provider_test.go
@@ -159,6 +159,30 @@ func TestGetHintStableForSameSVID(t *testing.T) {
 	require.NotEmpty(t, h1)
 }
 
+func TestIntermediatesReturnsNonLeafCerts(t *testing.T) {
+	t.Parallel()
+	leaf := mintTestSVID(t, "")
+	extra := mintTestSVID(t, "")
+
+	// Attach a second cert after the leaf to simulate a chain.
+	leaf.Certificates = append(leaf.Certificates, extra.Certificates[0])
+
+	p := &CredentialProvider{Source: &fakeSource{svid: leaf}}
+	require.NoError(t, p.Prepare(context.Background()))
+
+	ints := p.Intermediates()
+	require.Len(t, ints, 1)
+	require.Equal(t, extra.Certificates[0].Raw, ints[0].Raw)
+}
+
+func TestIntermediatesEmptyForLeafOnlySVID(t *testing.T) {
+	t.Parallel()
+	svid := mintTestSVID(t, "")
+	p := &CredentialProvider{Source: &fakeSource{svid: svid}}
+	require.NoError(t, p.Prepare(context.Background()))
+	require.Empty(t, p.Intermediates())
+}
+
 func TestKeypairAccessorsForECDSAP256(t *testing.T) {
 	t.Parallel()
 	svid := mintTestSVID(t, "")

--- a/spiffe/keypair.go
+++ b/spiffe/keypair.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package spiffe
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+)
+
+var _ sign.Keypair = (*svidKeypair)(nil)
+
+// svidKeypair satisfies sign.Keypair by delegating to the current X.509-SVID
+// from the injected source. Signing uses the SVID private key; key material
+// is refreshed on every call so SVID rotation is transparent.
+type svidKeypair struct {
+	source x509svid.Source
+}
+
+// GetHashAlgorithm returns SHA-256 for ECDSA/RSA SVIDs and SHA_UNSPECIFIED
+// for Ed25519 (which signs the raw message). Picked from the SVID's leaf.
+func (k *svidKeypair) GetHashAlgorithm() protocommon.HashAlgorithm {
+	pub := k.publicKey()
+	if _, ok := pub.(ed25519.PublicKey); ok {
+		return protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED
+	}
+	return protocommon.HashAlgorithm_SHA2_256
+}
+
+// GetSigningAlgorithm maps the SVID leaf's public key to the corresponding
+// protocommon.PublicKeyDetails. Unknown combinations return UNSPECIFIED.
+func (k *svidKeypair) GetSigningAlgorithm() protocommon.PublicKeyDetails {
+	switch pub := k.publicKey().(type) {
+	case *ecdsa.PublicKey:
+		switch pub.Curve {
+		case elliptic.P256():
+			return protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256
+		case elliptic.P384():
+			return protocommon.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384
+		case elliptic.P521():
+			return protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512
+		}
+	case *rsa.PublicKey:
+		// crypto.Signer defaults to PKCS1v15 when opts is a crypto.Hash,
+		// which is what SignData below uses, so advertise the matching
+		// PKCS1v15 algorithms.
+		switch pub.Size() * 8 {
+		case 2048:
+			return protocommon.PublicKeyDetails_PKIX_RSA_PKCS1V15_2048_SHA256
+		case 3072:
+			return protocommon.PublicKeyDetails_PKIX_RSA_PKCS1V15_3072_SHA256
+		case 4096:
+			return protocommon.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256
+		}
+	case ed25519.PublicKey:
+		return protocommon.PublicKeyDetails_PKIX_ED25519
+	}
+	return protocommon.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED
+}
+
+// GetHint returns a stable, opaque identifier for the SVID public key,
+// matching sigstore-go's base64(sha256(DER(PKIX))) convention.
+func (k *svidKeypair) GetHint() []byte {
+	pub := k.publicKey()
+	if pub == nil {
+		return nil
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil
+	}
+	sum := sha256.Sum256(der)
+	return []byte(base64.StdEncoding.EncodeToString(sum[:]))
+}
+
+// GetKeyAlgorithm maps the SVID public key type to the string tokens used
+// by sigstore-go's Fulcio client. Mirrors EphemeralKeypair's mapping for
+// consistency; Fulcio isn't called on the SPIFFE path.
+func (k *svidKeypair) GetKeyAlgorithm() string {
+	switch k.publicKey().(type) {
+	case *ecdsa.PublicKey:
+		return "ECDSA"
+	case *rsa.PublicKey:
+		return "RSA"
+	case ed25519.PublicKey:
+		return "ED25519"
+	}
+	return ""
+}
+
+// GetPublicKey returns the SVID leaf public key.
+func (k *svidKeypair) GetPublicKey() crypto.PublicKey { return k.publicKey() }
+
+// GetPublicKeyPem PEM-encodes the SVID leaf public key.
+func (k *svidKeypair) GetPublicKeyPem() (string, error) {
+	pub := k.publicKey()
+	if pub == nil {
+		return "", errors.New("svid has no certificates")
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})), nil
+}
+
+// SignData signs the data with the current SVID private key. For ECDSA and
+// RSA, data is hashed with SHA-256 first; for Ed25519, the raw data is
+// signed. Returns (signature, dataToSign) matching sigstore-go's
+// EphemeralKeypair contract.
+func (k *svidKeypair) SignData(_ context.Context, data []byte) (signature, signed []byte, err error) {
+	svid, err := k.source.GetX509SVID()
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching svid: %w", err)
+	}
+	if svid.PrivateKey == nil {
+		return nil, nil, errors.New("svid has no private key")
+	}
+
+	if _, ok := svid.PrivateKey.Public().(ed25519.PublicKey); ok {
+		sig, err := svid.PrivateKey.Sign(rand.Reader, data, crypto.Hash(0))
+		if err != nil {
+			return nil, nil, fmt.Errorf("signing with svid private key: %w", err)
+		}
+		return sig, data, nil
+	}
+
+	hasher := sha256.New()
+	hasher.Write(data)
+	digest := hasher.Sum(nil)
+
+	sig, signErr := svid.PrivateKey.Sign(rand.Reader, digest, crypto.SHA256)
+	if signErr != nil {
+		return nil, nil, fmt.Errorf("signing with svid private key: %w", signErr)
+	}
+	return sig, digest, nil
+}
+
+// publicKey returns the SVID leaf public key, or nil if the source has no
+// SVID yet. Used by the accessor methods that can't return an error.
+func (k *svidKeypair) publicKey() crypto.PublicKey {
+	svid, err := k.source.GetX509SVID()
+	if err != nil || len(svid.Certificates) == 0 {
+		return nil
+	}
+	return svid.Certificates[0].PublicKey
+}


### PR DESCRIPTION
This pull request introduces support for handling X.509 intermediate certificates in the signing workflow, with a particular focus on enabling correct bundle construction for SPIFFE-based credential providers. It updates the `CredentialProvider` interface to expose intermediates, implements this for both SPIFFE and sigstore providers, and ensures that signed bundles include intermediates when available. Comprehensive tests are added to verify the new behavior.

**Interface and API changes:**

* The `CredentialProvider` interface in `bundle/credential_provider.go` now includes a new method `Intermediates()` that returns the chain of intermediate certificates between the leaf and the trust anchor, to be embedded in bundles where applicable.
* The fake implementation in `bundle/bundlefakes/fake_credential_provider.go` is extended to support the new `Intermediates` method for testing. [[1]](diffhunk://#diff-e061f4d91912318bd392a4942323e9b56f0f381ca6a36310307c80d6347eff86R26-R35) [[2]](diffhunk://#diff-e061f4d91912318bd392a4942323e9b56f0f381ca6a36310307c80d6347eff86R117-R169)

**SPIFFE provider implementation:**

* Adds a new SPIFFE credential provider in `spiffe/credential_provider.go` that implements the updated interface, including logic to extract intermediates from the SVID, and a corresponding certificate provider in `spiffe/cert_provider.go`. [[1]](diffhunk://#diff-197b4e783a6765c32ccd3eb0228b9340e2e6e019a1cb3d11e3832ccc8e1eed2fR1-R130) [[2]](diffhunk://#diff-f6cb10da708e0317c6eefe99737888e61fac1fa651b5fc6a27c5fdb7b3bc67acR1-R34)

**Bundle construction and signing:**

* Updates the `Signer` in `signer.go` to call a new `attachIntermediates` helper after signing: if intermediates are present, the bundle's `VerificationMaterial` is rewritten to include the full certificate chain. [[1]](diffhunk://#diff-382c42121d78e1b3f93f4e60409563c2e7ca0026d2ebe9bbac2105bb4f5003e0R158-R160) [[2]](diffhunk://#diff-382c42121d78e1b3f93f4e60409563c2e7ca0026d2ebe9bbac2105bb4f5003e0R189-R235)

**Provider-specific behavior:**

* The sigstore credential provider is updated to explicitly return `nil` for intermediates, preserving existing behavior where the chain is reconstructed at verification time.

**Testing:**

* Adds thorough tests in `signer_test.go` to verify that bundles are correctly constructed with and without intermediates, including a helper to mint test certificates.

**Dependency updates:**

* Adds `github.com/spiffe/go-spiffe/v2` as a dependency in `go.mod` for SPIFFE support.

These changes collectively improve the handling of certificate chains in signed bundles, enabling compatibility with SPIFFE and future providers that require intermediates to be embedded.