### PR TITLE
Add SPIFFE verifier

### DIFF
--- a/bundle/verifier.go
+++ b/bundle/verifier.go
@@ -4,6 +4,7 @@
 package bundle
 
 import (
+	"crypto/x509"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -43,6 +44,15 @@ func WithSigstoreRootsData(data []byte) BundleOptsFunc {
 	}
 }
 
+// WithSpiffeVerifier installs the verifier used when a bundle carries a
+// SPIFFE-shaped identity (leaf cert with a spiffe:// URI SAN).
+func WithSpiffeVerifier(sv SpiffeVerifier) BundleOptsFunc {
+	return func(v *DefaultVerifier) error {
+		v.SPIFFE = sv
+		return nil
+	}
+}
+
 // New creates a new verifier. Initialization errors are logged to stderr
 // but not returned. Use NewWithError if you need to handle errors.
 func New(funcs ...BundleOptsFunc) Verifier {
@@ -70,6 +80,13 @@ type VerifyCapable interface {
 	Verify(verify.SignedEntity, verify.PolicyBuilder) (*verify.VerificationResult, error)
 }
 
+// SpiffeVerifier verifies bundles signed against a SPIFFE/SPIRE trust domain.
+// Implemented by spiffe.Verifier; typed as an interface here so the bundle
+// package doesn't have to import the spiffe package.
+type SpiffeVerifier interface {
+	Verify(*options.Verification, *bundle.Bundle) (*verify.VerificationResult, error)
+}
+
 // BundleVerifier abstracts the verification implementation to make it easy to
 // mock for testing.
 //
@@ -84,6 +101,11 @@ type Verifier interface {
 // DefaultVerifier implements the BundleVerifier interface.
 type DefaultVerifier struct {
 	Verifiers []VerifyCapable
+
+	// SPIFFE, when set, handles bundles whose leaf certificate carries a
+	// spiffe:// URI SAN. Constructed outside this package (typically in
+	// signer.NewVerifier) to avoid a bundle -> spiffe import dependency.
+	SPIFFE SpiffeVerifier
 }
 
 // OpenBundle opens a bundle file
@@ -95,8 +117,16 @@ func (bv *DefaultVerifier) OpenBundle(path string) (*bundle.Bundle, error) {
 	return b, nil
 }
 
-// Verify is the main verification function to check bundles
+// Verify is the main verification function to check bundles. Dispatches to
+// the SPIFFE verifier when the bundle carries a spiffe:// URI SAN; otherwise
+// iterates the configured sigstore instances.
 func (bv *DefaultVerifier) Verify(opts *options.Verification, bndl *bundle.Bundle) (*verify.VerificationResult, error) {
+	if isSpiffeBundle(bndl) {
+		if bv.SPIFFE == nil {
+			return nil, errors.New("bundle carries a spiffe identity but no spiffe verifier is configured")
+		}
+		return bv.SPIFFE.Verify(opts, bndl)
+	}
 	if len(bv.Verifiers) == 0 {
 		return nil, fmt.Errorf("unable to verify bundle, no sigstore instances loaded")
 	}
@@ -267,6 +297,34 @@ func (bv *DefaultVerifier) RunVerification(
 	}
 
 	return res, nil
+}
+
+// isSpiffeBundle reports whether the bundle's leaf certificate carries a
+// spiffe:// URI SAN. Used to dispatch between the sigstore and SPIFFE paths.
+func isSpiffeBundle(bndl *bundle.Bundle) bool {
+	vm := bndl.GetVerificationMaterial()
+	if vm == nil {
+		return false
+	}
+	var der []byte
+	if chain := vm.GetX509CertificateChain(); chain != nil && len(chain.GetCertificates()) > 0 {
+		der = chain.GetCertificates()[0].GetRawBytes()
+	} else if cert := vm.GetCertificate(); cert != nil {
+		der = cert.GetRawBytes()
+	}
+	if len(der) == 0 {
+		return false
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return false
+	}
+	for _, uri := range leaf.URIs {
+		if uri.Scheme == "spiffe" {
+			return true
+		}
+	}
+	return false
 }
 
 // hashAlgorithmToString maps a protobuf HashAlgorithm enum to the string

--- a/dsse/verifier.go
+++ b/dsse/verifier.go
@@ -55,7 +55,7 @@ func (dv *DefaultVerifier) RunVerification(
 
 	// Precompute PAE digests for keys that verify via prehash. ED25519 and
 	// GPG-wrapped signatures operate on the raw PAE message, so skip them.
-	paeMessage := paeEncode(env)
+	paeMessage := PAEEncode(env)
 	digests := map[crypto.Hash][]byte{}
 	digestStrs := map[string]string{}
 	for _, k := range publicKeys {
@@ -165,19 +165,19 @@ func hashPayload(env *sdsse.Envelope, hasher crypto.Hash) ([]byte, error) {
 		return nil, errors.New("unset payload type in DSSE envelope")
 	}
 
-	paeEncoded := paeEncode(env)
+	PAEEncoded := PAEEncode(env)
 
 	h := hasher.New()
-	if _, err := h.Write(paeEncoded); err != nil {
+	if _, err := h.Write(PAEEncoded); err != nil {
 		return nil, fmt.Errorf("writing to hasher: %w", err)
 	}
 	return h.Sum(nil), nil
 }
 
-// paeEncode implements the DSSE signing protocol:
+// PAEEncode implements the DSSE signing protocol:
 // https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#signature-definition
 // This function was stolen from the Secure System Labs dsse packager.
-func paeEncode(env *sdsse.Envelope) []byte {
+func PAEEncode(env *sdsse.Envelope) []byte {
 	// payloadType string, payload []byte) []byte {
 	return fmt.Appendf(nil, "DSSEv1 %d %s %d %s",
 		len(env.GetPayloadType()), env.GetPayloadType(),

--- a/options/verification.go
+++ b/options/verification.go
@@ -15,9 +15,34 @@ type VerificationOptFunc func(*Verification) error
 type Verification struct {
 	SigstoreVerification
 	KeyVerification
+	SpiffeVerification
 }
 
 var DefaultVerification = Verification{}
+
+// SpiffeVerification carries the trust material and identity matchers used
+// when verifying a bundle signed against a SPIFFE/SPIRE trust domain.
+type SpiffeVerification struct {
+	// TrustRootsPEM is the inline PEM-encoded set of trust anchors used to
+	// validate the SVID chain. At least one of TrustRootsPEM or
+	// TrustRootsPath must be set for SPIFFE verification to be enabled.
+	TrustRootsPEM []byte
+
+	// TrustRootsPath is a filesystem path to a PEM-encoded trust anchor file.
+	TrustRootsPath string
+
+	// ExpectedTrustDomain, when non-empty, asserts the leaf SVID's trust
+	// domain matches this string (e.g. "prod.example.org").
+	ExpectedTrustDomain string
+
+	// ExpectedPath, when non-empty, requires an exact match on the SVID's
+	// SPIFFE path component (e.g. "/workload/api").
+	ExpectedPath string
+
+	// ExpectedPathRegex, when non-empty, requires a regex match on the SVID's
+	// SPIFFE path component. Mutually exclusive with ExpectedPath.
+	ExpectedPathRegex string
+}
 
 // WithExpectedIdentity serts the ExpectedIssuer and ExptectedSan options
 // and unsets the regex alternatives
@@ -64,6 +89,51 @@ func WithExpectedIdentityRegex(issuer, san string) VerificationOptFunc {
 func WithSkipIdentityCheck(yesno bool) VerificationOptFunc {
 	return func(v *Verification) error {
 		v.SkipIdentityCheck = yesno
+		return nil
+	}
+}
+
+// WithSpiffeTrustRootsPEM sets the inline PEM-encoded SPIFFE trust anchors.
+func WithSpiffeTrustRootsPEM(pem []byte) VerificationOptFunc {
+	return func(v *Verification) error {
+		v.TrustRootsPEM = pem
+		return nil
+	}
+}
+
+// WithSpiffeTrustRootsFile sets the filesystem path to a PEM-encoded SPIFFE
+// trust anchor file.
+func WithSpiffeTrustRootsFile(path string) VerificationOptFunc {
+	return func(v *Verification) error {
+		v.TrustRootsPath = path
+		return nil
+	}
+}
+
+// WithExpectedSpiffeID sets the expected trust domain and path for the SVID
+// leaf. Either can be empty to skip that check; both together form an exact
+// match (use WithExpectedSpiffeIDRegex for pattern matching on the path).
+func WithExpectedSpiffeID(trustDomain, path string) VerificationOptFunc {
+	return func(v *Verification) error {
+		v.ExpectedTrustDomain = trustDomain
+		v.ExpectedPath = path
+		v.ExpectedPathRegex = ""
+		return nil
+	}
+}
+
+// WithExpectedSpiffeIDRegex sets the expected trust domain and a regex that
+// must match the SVID path. Unsets any exact ExpectedPath.
+func WithExpectedSpiffeIDRegex(trustDomain, pathRegex string) VerificationOptFunc {
+	return func(v *Verification) error {
+		if pathRegex != "" {
+			if _, err := regexp.Compile(pathRegex); err != nil {
+				return fmt.Errorf("compiling spiffe path regex: %w", err)
+			}
+		}
+		v.ExpectedTrustDomain = trustDomain
+		v.ExpectedPathRegex = pathRegex
+		v.ExpectedPath = ""
 		return nil
 	}
 }

--- a/signer.go
+++ b/signer.go
@@ -230,6 +230,10 @@ func (s *Signer) attachIntermediates(bndl *protobundle.Bundle) error {
 	bndl.VerificationMaterial.Content = &protobundle.VerificationMaterial_X509CertificateChain{
 		X509CertificateChain: chain,
 	}
+	// sigstore-go's sbundle.NewBundle rejects X509CertificateChain content at
+	// v0.3 (only single Certificate allowed). v0.2 permits the chain variant,
+	// which is exactly what SPIFFE signing needs to carry intermediates.
+	bndl.MediaType = "application/vnd.dev.sigstore.bundle+json;version=0.2"
 	return nil
 }
 

--- a/spiffe/verifier.go
+++ b/spiffe/verifier.go
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package spiffe
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/carabiner-dev/signer/dsse"
+	"github.com/carabiner-dev/signer/options"
+)
+
+// VerifierOptions configures a SPIFFE Verifier.
+type VerifierOptions struct {
+	// TrustRoots is the certificate pool used to validate the SVID chain.
+	// Required.
+	TrustRoots *x509.CertPool
+
+	// ExpectedTrustDomain, when non-zero, asserts the SVID's trust domain.
+	ExpectedTrustDomain spiffeid.TrustDomain
+
+	// ExpectedPath, when non-empty, requires an exact match on the SVID's
+	// SPIFFE path component.
+	ExpectedPath string
+
+	// ExpectedPathRegex, when non-nil, must match the SVID's SPIFFE path.
+	// Mutually exclusive with ExpectedPath.
+	ExpectedPathRegex *regexp.Regexp
+}
+
+// Verifier validates SPIFFE-signed bundles against a pinned SPIRE trust root
+// and enforces SPIFFE identity matchers on the SVID leaf.
+type Verifier struct {
+	opts VerifierOptions
+}
+
+// NewVerifier creates a SPIFFE Verifier. Returns an error if the trust roots
+// are missing or the identity matchers are ambiguous.
+func NewVerifier(opts VerifierOptions) (*Verifier, error) {
+	if opts.TrustRoots == nil {
+		return nil, errors.New("spiffe verifier requires at least one trust root")
+	}
+	if opts.ExpectedPath != "" && opts.ExpectedPathRegex != nil {
+		return nil, errors.New("spiffe verifier: ExpectedPath and ExpectedPathRegex are mutually exclusive")
+	}
+	return &Verifier{opts: opts}, nil
+}
+
+// NewVerifierFromOptions builds a Verifier from the verification options
+// struct carried in the top-level options.Verification. Loads trust roots
+// from inline PEM or a file as configured.
+func NewVerifierFromOptions(opts *options.SpiffeVerification) (*Verifier, error) {
+	pool, err := loadTrustRoots(opts)
+	if err != nil {
+		return nil, fmt.Errorf("loading spiffe trust roots: %w", err)
+	}
+	vOpts := VerifierOptions{TrustRoots: pool, ExpectedPath: opts.ExpectedPath}
+	if opts.ExpectedTrustDomain != "" {
+		td, err := spiffeid.TrustDomainFromString(opts.ExpectedTrustDomain)
+		if err != nil {
+			return nil, fmt.Errorf("parsing expected trust domain: %w", err)
+		}
+		vOpts.ExpectedTrustDomain = td
+	}
+	if opts.ExpectedPathRegex != "" {
+		re, err := regexp.Compile(opts.ExpectedPathRegex)
+		if err != nil {
+			return nil, fmt.Errorf("compiling spiffe path regex: %w", err)
+		}
+		vOpts.ExpectedPathRegex = re
+	}
+	return NewVerifier(vOpts)
+}
+
+func loadTrustRoots(opts *options.SpiffeVerification) (*x509.CertPool, error) {
+	var data []byte
+	if opts.TrustRootsPath != "" {
+		b, err := os.ReadFile(opts.TrustRootsPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading trust roots file: %w", err)
+		}
+		data = append(data, b...)
+	}
+	if len(opts.TrustRootsPEM) > 0 {
+		data = append(data, opts.TrustRootsPEM...)
+	}
+	if len(data) == 0 {
+		return nil, errors.New("no trust roots configured")
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, errors.New("no valid PEM certificates found in trust roots")
+	}
+	return pool, nil
+}
+
+// Verify validates the SVID chain in the bundle against the pinned trust
+// roots, enforces the SPIFFE identity matchers, and verifies the DSSE
+// envelope signature against the leaf public key. Returns a best-effort
+// *verify.VerificationResult on success (sigstore-specific fields like
+// transparency-log entries are left zero; SPIFFE signatures don't produce
+// them).
+func (v *Verifier) Verify(_ *options.Verification, bndl *sbundle.Bundle) (*verify.VerificationResult, error) {
+	chain, err := extractChain(bndl)
+	if err != nil {
+		return nil, fmt.Errorf("extracting x509 chain from bundle: %w", err)
+	}
+	leaf := chain[0]
+
+	intermediates := x509.NewCertPool()
+	for _, c := range chain[1:] {
+		intermediates.AddCert(c)
+	}
+
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         v.opts.TrustRoots,
+		Intermediates: intermediates,
+		// Accept any EKU — SPIRE SVIDs typically don't set a code-signing EKU.
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return nil, fmt.Errorf("chain verification failed: %w", err)
+	}
+
+	id, err := extractSpiffeID(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("extracting spiffe id: %w", err)
+	}
+	if err := v.matchIdentity(id); err != nil {
+		return nil, err
+	}
+
+	if err := verifyDSSESignature(bndl, leaf.PublicKey); err != nil {
+		return nil, fmt.Errorf("verifying dsse signature: %w", err)
+	}
+
+	return buildResult(bndl), nil
+}
+
+func (v *Verifier) matchIdentity(id spiffeid.ID) error {
+	if !v.opts.ExpectedTrustDomain.IsZero() && id.TrustDomain() != v.opts.ExpectedTrustDomain {
+		return fmt.Errorf(
+			"spiffe id trust domain %q does not match expected %q",
+			id.TrustDomain(), v.opts.ExpectedTrustDomain,
+		)
+	}
+	if v.opts.ExpectedPath != "" && id.Path() != v.opts.ExpectedPath {
+		return fmt.Errorf("spiffe id path %q does not match expected %q", id.Path(), v.opts.ExpectedPath)
+	}
+	if v.opts.ExpectedPathRegex != nil && !v.opts.ExpectedPathRegex.MatchString(id.Path()) {
+		return fmt.Errorf(
+			"spiffe id path %q does not match regex %q",
+			id.Path(), v.opts.ExpectedPathRegex,
+		)
+	}
+	return nil
+}
+
+// extractChain pulls the X.509 chain out of the bundle's VerificationMaterial.
+// Accepts either an X509CertificateChain (leaf + intermediates) or a single
+// Certificate (leaf only).
+func extractChain(bndl *sbundle.Bundle) ([]*x509.Certificate, error) {
+	vm := bndl.GetVerificationMaterial()
+	if vm == nil {
+		return nil, errors.New("bundle has no verification material")
+	}
+	if chain := vm.GetX509CertificateChain(); chain != nil && len(chain.GetCertificates()) > 0 {
+		out := make([]*x509.Certificate, 0, len(chain.GetCertificates()))
+		for i, c := range chain.GetCertificates() {
+			cert, err := x509.ParseCertificate(c.GetRawBytes())
+			if err != nil {
+				return nil, fmt.Errorf("parsing certificate %d: %w", i, err)
+			}
+			out = append(out, cert)
+		}
+		return out, nil
+	}
+	if leaf := vm.GetCertificate(); leaf != nil {
+		cert, err := x509.ParseCertificate(leaf.GetRawBytes())
+		if err != nil {
+			return nil, fmt.Errorf("parsing leaf certificate: %w", err)
+		}
+		return []*x509.Certificate{cert}, nil
+	}
+	return nil, errors.New("bundle verification material has no certificate")
+}
+
+// extractSpiffeID pulls the first spiffe:// URI SAN from the leaf.
+func extractSpiffeID(leaf *x509.Certificate) (spiffeid.ID, error) {
+	for _, uri := range leaf.URIs {
+		if uri.Scheme == "spiffe" {
+			return spiffeid.FromURI(uri)
+		}
+	}
+	return spiffeid.ID{}, errors.New("leaf certificate has no spiffe:// URI SAN")
+}
+
+// verifyDSSESignature checks that at least one signature in the bundle's DSSE
+// envelope verifies against the given public key.
+func verifyDSSESignature(bndl *sbundle.Bundle, pub crypto.PublicKey) error {
+	env := bndl.GetDsseEnvelope()
+	if env == nil {
+		return errors.New("bundle has no DSSE envelope")
+	}
+	sigs := env.GetSignatures()
+	if len(sigs) == 0 {
+		return errors.New("DSSE envelope has no signatures")
+	}
+
+	pae := dsse.PAEEncode(env)
+
+	var lastErr error
+	for _, sig := range sigs {
+		if err := verifyWithKey(pub, pae, sig.GetSig()); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	return fmt.Errorf("no signature verified against leaf key: %w", lastErr)
+}
+
+// verifyWithKey dispatches signature verification on the leaf public key
+// type. Mirrors the algorithm choices made by spiffe.svidKeypair.SignData.
+func verifyWithKey(pub crypto.PublicKey, msg, sig []byte) error {
+	switch k := pub.(type) {
+	case *ecdsa.PublicKey:
+		digest := sha256.Sum256(msg)
+		if !ecdsa.VerifyASN1(k, digest[:], sig) {
+			return errors.New("ecdsa verification failed")
+		}
+		return nil
+	case *rsa.PublicKey:
+		digest := sha256.Sum256(msg)
+		return rsa.VerifyPKCS1v15(k, crypto.SHA256, digest[:], sig)
+	case ed25519.PublicKey:
+		if !ed25519.Verify(k, msg, sig) {
+			return errors.New("ed25519 verification failed")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported leaf public key type: %T", pub)
+	}
+}
+
+// buildResult constructs a best-effort VerificationResult. Tries to parse the
+// DSSE payload as an in-toto Statement and populate it; leaves timestamps and
+// transparency-log fields empty (SPIFFE signatures don't produce them).
+func buildResult(bndl *sbundle.Bundle) *verify.VerificationResult {
+	result := verify.NewVerificationResult()
+	env := bndl.GetDsseEnvelope()
+	if env == nil || len(env.GetPayload()) == 0 {
+		return result
+	}
+	st := &intoto.Statement{}
+	if err := protojson.Unmarshal(env.GetPayload(), st); err == nil {
+		result.Statement = st
+	}
+	return result
+}

--- a/spiffe/verifier_test.go
+++ b/spiffe/verifier_test.go
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package spiffe
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/url"
+	"regexp"
+	"testing"
+	"time"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/signer/dsse"
+	"github.com/carabiner-dev/signer/options"
+)
+
+// testPKI is a minimal CA + leaf pair used across verifier tests.
+type testPKI struct {
+	root    *x509.Certificate
+	leaf    *x509.Certificate
+	leafKey *ecdsa.PrivateKey
+}
+
+// newTestPKI mints a self-signed root CA and a leaf cert whose URI SAN is
+// spiffe://example.org<path>. Both use ECDSA-P256; the leaf is signed by
+// the root.
+func newTestPKI(t *testing.T, path string) *testPKI {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-spire-root"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTpl, rootTpl, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	root, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	id := spiffeid.RequireFromPath(spiffeid.RequireTrustDomainFromString("example.org"), path)
+	leafTpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "svid"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		URIs:                  []*url.URL{id.URL()},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTpl, root, &leafKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	return &testPKI{root: root, leaf: leaf, leafKey: leafKey}
+}
+
+func (p *testPKI) rootPool() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(p.root)
+	return pool
+}
+
+func (p *testPKI) rootPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: p.root.Raw})
+}
+
+// makeSignedBundle constructs a sigstore Bundle containing a DSSE envelope
+// signed with the leaf key and a chain carrying just the leaf.
+func makeSignedBundle(t *testing.T, p *testPKI, payload []byte) *sbundle.Bundle {
+	t.Helper()
+
+	env := &sdsse.Envelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     payload,
+	}
+	pae := dsse.PAEEncode(env)
+	digest := sha256.Sum256(pae)
+	sig, err := p.leafKey.Sign(rand.Reader, digest[:], crypto.SHA256)
+	require.NoError(t, err)
+	env.Signatures = []*sdsse.Signature{{Sig: sig}}
+
+	// v0.2 MediaType — v0.3+ forbids the X509CertificateChain variant.
+	pb := &protobundle.Bundle{
+		MediaType: "application/vnd.dev.sigstore.bundle+json;version=0.2",
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: &protocommon.X509CertificateChain{
+					Certificates: []*protocommon.X509Certificate{
+						{RawBytes: p.leaf.Raw},
+					},
+				},
+			},
+		},
+		Content: &protobundle.Bundle_DsseEnvelope{DsseEnvelope: env},
+	}
+	b, err := sbundle.NewBundle(pb)
+	require.NoError(t, err)
+	return b
+}
+
+var testPayload = []byte(`{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"test"}],"predicateType":"https://example.com/pred/v1","predicate":{}}`)
+
+func TestVerifierSuccess(t *testing.T) {
+	t.Parallel()
+	pki := newTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	v, err := NewVerifier(VerifierOptions{
+		TrustRoots:          pki.rootPool(),
+		ExpectedTrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
+		ExpectedPath:        "/workload",
+	})
+	require.NoError(t, err)
+
+	result, err := v.Verify(nil, bndl)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestVerifierFromOptionsViaPEM(t *testing.T) {
+	t.Parallel()
+	pki := newTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	v, err := NewVerifierFromOptions(&options.SpiffeVerification{
+		TrustRootsPEM:       pki.rootPEM(),
+		ExpectedTrustDomain: "example.org",
+		ExpectedPath:        "/workload",
+	})
+	require.NoError(t, err)
+
+	_, err = v.Verify(nil, bndl)
+	require.NoError(t, err)
+}
+
+func TestVerifierRejectsWrongTrustDomain(t *testing.T) {
+	t.Parallel()
+	pki := newTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	v, err := NewVerifier(VerifierOptions{
+		TrustRoots:          pki.rootPool(),
+		ExpectedTrustDomain: spiffeid.RequireTrustDomainFromString("other.example"),
+	})
+	require.NoError(t, err)
+
+	_, err = v.Verify(nil, bndl)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "trust domain")
+}
+
+func TestVerifierRejectsWrongPath(t *testing.T) {
+	t.Parallel()
+	pki := newTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	v, err := NewVerifier(VerifierOptions{
+		TrustRoots:   pki.rootPool(),
+		ExpectedPath: "/other",
+	})
+	require.NoError(t, err)
+
+	_, err = v.Verify(nil, bndl)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path")
+}
+
+func TestVerifierAcceptsPathRegex(t *testing.T) {
+	t.Parallel()
+	pki := newTestPKI(t, "/workload/api")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	v, err := NewVerifier(VerifierOptions{
+		TrustRoots:        pki.rootPool(),
+		ExpectedPathRegex: regexp.MustCompile(`^/workload/.*$`),
+	})
+	require.NoError(t, err)
+
+	_, err = v.Verify(nil, bndl)
+	require.NoError(t, err)
+}
+
+func TestVerifierRejectsUntrustedRoot(t *testing.T) {
+	t.Parallel()
+	signer := newTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, signer, testPayload)
+
+	// Build a verifier pool from a *different* CA.
+	other := newTestPKI(t, "/other")
+
+	v, err := NewVerifier(VerifierOptions{TrustRoots: other.rootPool()})
+	require.NoError(t, err)
+
+	_, err = v.Verify(nil, bndl)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chain verification failed")
+}
+
+func TestVerifierRejectsTamperedPayload(t *testing.T) {
+	t.Parallel()
+	pki := newTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	// Tamper with the envelope's payload post-signing. The signature was
+	// over the original payload, so PAE reconstruction will mismatch.
+	env := bndl.GetDsseEnvelope()
+	env.Payload = []byte(`{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"EVIL"}]}`)
+
+	v, err := NewVerifier(VerifierOptions{TrustRoots: pki.rootPool()})
+	require.NoError(t, err)
+
+	_, err = v.Verify(nil, bndl)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dsse signature")
+}
+
+func TestNewVerifierRequiresTrustRoots(t *testing.T) {
+	t.Parallel()
+	_, err := NewVerifier(VerifierOptions{})
+	require.Error(t, err)
+}
+
+func TestNewVerifierRejectsAmbiguousPathMatch(t *testing.T) {
+	t.Parallel()
+	pool := x509.NewCertPool()
+	pool.AddCert(newTestPKI(t, "/workload").root)
+
+	_, err := NewVerifier(VerifierOptions{
+		TrustRoots:        pool,
+		ExpectedPath:      "/a",
+		ExpectedPathRegex: regexp.MustCompile(`.*`),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestNewVerifierFromOptionsRejectsInvalidPEM(t *testing.T) {
+	t.Parallel()
+	_, err := NewVerifierFromOptions(&options.SpiffeVerification{
+		TrustRootsPEM: []byte("not a PEM block"),
+	})
+	require.Error(t, err)
+}

--- a/verifier.go
+++ b/verifier.go
@@ -9,11 +9,13 @@ import (
 	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/sirupsen/logrus"
 
 	"github.com/carabiner-dev/signer/bundle"
 	"github.com/carabiner-dev/signer/dsse"
 	"github.com/carabiner-dev/signer/key"
 	"github.com/carabiner-dev/signer/options"
+	"github.com/carabiner-dev/signer/spiffe"
 )
 
 // NewVerifier creates a new verifier with default options and verifiers
@@ -23,7 +25,19 @@ func NewVerifier(fnOpts ...options.VerifierOptFunc) *Verifier {
 		f(&opts)
 	}
 
-	bv := bundle.New(bundle.WithSigstoreRootsData(opts.SigstoreRootsData))
+	bundleOpts := []bundle.BundleOptsFunc{bundle.WithSigstoreRootsData(opts.SigstoreRootsData)}
+	if opts.TrustRootsPEM != nil || opts.TrustRootsPath != "" {
+		sv, err := spiffe.NewVerifierFromOptions(&opts.SpiffeVerification)
+		if err != nil {
+			// Initialization errors are logged but not fatal, matching the
+			// bundle.New contract for the sigstore-roots option.
+			logrus.Errorf("building spiffe verifier: %v", err)
+		} else {
+			bundleOpts = append(bundleOpts, bundle.WithSpiffeVerifier(sv))
+		}
+	}
+
+	bv := bundle.New(bundleOpts...)
 	return &Verifier{
 		Options:        opts,
 		bundleVerifier: bv,


### PR DESCRIPTION
We now check the spiffe verifier. If the payload is a v0.2 bundle that looks signed with a spire key, we dispatch it to the spiffe verifier.