### PR TITLE
Add and wire SPIFFE identity type

### DIFF
--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -4,9 +4,12 @@
 package v1
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 
 	"github.com/carabiner-dev/signer/key"
 )
@@ -108,6 +111,48 @@ func (i *Identity) Validate() error {
 		errs = append(errs, fmt.Errorf("only one type of identity can be set at a time (got %v)", typesDefined))
 	}
 	return errors.Join(errs...)
+}
+
+// IdentitySpiffeFromString parses a SPIFFE ID string (e.g.
+// "spiffe://example.org/workload") into an IdentitySpiffe populated with the
+// parsed trust domain and path. This is the primary helper for turning the
+// SPIFFE ID a verifier surfaces in its VerificationResult (via
+// VerifiedIdentity.SubjectAlternativeName) into an api/v1 identity value
+// suitable for SignatureVerification.Identities.
+//
+// TrustRoots is intentionally NOT populated — it is verifier configuration
+// (which root(s) the chain was validated against), not an attribute of the
+// signer. Policy-side IdentitySpiffe values carry TrustRoots to tell the
+// verifier what to trust; verified-side IdentitySpiffe values describe who
+// signed.
+func IdentitySpiffeFromString(spiffeID string) (*IdentitySpiffe, error) {
+	id, err := spiffeid.FromString(spiffeID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing spiffe id: %w", err)
+	}
+	return &IdentitySpiffe{
+		TrustDomain: id.TrustDomain().Name(),
+		Path:        id.Path(),
+	}, nil
+}
+
+// IdentitySpiffeFromCert builds an IdentitySpiffe from a leaf certificate by
+// extracting the SPIFFE ID from its URI SAN. Delegates to
+// IdentitySpiffeFromString once the SAN is found. Useful when a caller has
+// only the leaf (e.g. test fixtures or standalone cert inspection); when a
+// VerificationResult is available, read the SAN from VerifiedIdentity and
+// call IdentitySpiffeFromString directly.
+func IdentitySpiffeFromCert(leaf *x509.Certificate) (*IdentitySpiffe, error) {
+	if leaf == nil {
+		return nil, errors.New("leaf certificate is nil")
+	}
+	for _, uri := range leaf.URIs {
+		if uri.Scheme != "spiffe" {
+			continue
+		}
+		return IdentitySpiffeFromString(uri.String())
+	}
+	return nil, errors.New("certificate has no spiffe:// URI SAN")
 }
 
 // IdentityKeyFromPublic builds an IdentityKey from a verified *key.Public.

--- a/api/v1/identity.pb.go
+++ b/api/v1/identity.pb.go
@@ -29,12 +29,14 @@ const (
 //	a) A sigstore identity
 //	b) A key
 //	c) A reference to an identity defined outside the policy
+//	d) A SPIFFE identity
 type Identity struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Sigstore      *IdentitySigstore      `protobuf:"bytes,2,opt,name=sigstore,proto3,oneof" json:"sigstore,omitempty"`
 	Key           *IdentityKey           `protobuf:"bytes,3,opt,name=key,proto3,oneof" json:"key,omitempty"`
 	Ref           *IdentityRef           `protobuf:"bytes,4,opt,name=ref,proto3,oneof" json:"ref,omitempty"`
+	Spiffe        *IdentitySpiffe        `protobuf:"bytes,5,opt,name=spiffe,proto3,oneof" json:"spiffe,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -93,6 +95,13 @@ func (x *Identity) GetKey() *IdentityKey {
 func (x *Identity) GetRef() *IdentityRef {
 	if x != nil {
 		return x.Ref
+	}
+	return nil
+}
+
+func (x *Identity) GetSpiffe() *IdentitySpiffe {
+	if x != nil {
+		return x.Spiffe
 	}
 	return nil
 }
@@ -274,19 +283,97 @@ func (x *IdentityRef) GetId() string {
 	return ""
 }
 
+// IdentitySpiffe matches signatures produced by a SPIFFE workload. The
+// trust_domain is required; path / path_regex are optional matchers on the
+// SVID's SPIFFE path component (mutually exclusive).
+//
+// trust_roots inlines the PEM-encoded SPIRE upstream CA root(s) used to
+// validate the SVID chain, analogous to IdentityKey.data. Unlike the sigstore
+// flow there is no universal trust-root registry for SPIFFE, so the policy
+// must carry (or reference) the anchor itself.
+type IdentitySpiffe struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TrustDomain   string                 `protobuf:"bytes,1,opt,name=trust_domain,json=trustDomain,proto3" json:"trust_domain,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	PathRegex     string                 `protobuf:"bytes,3,opt,name=path_regex,json=pathRegex,proto3" json:"path_regex,omitempty"`
+	TrustRoots    string                 `protobuf:"bytes,4,opt,name=trust_roots,json=trustRoots,proto3" json:"trust_roots,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdentitySpiffe) Reset() {
+	*x = IdentitySpiffe{}
+	mi := &file_carabiner_signer_v1_identity_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentitySpiffe) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentitySpiffe) ProtoMessage() {}
+
+func (x *IdentitySpiffe) ProtoReflect() protoreflect.Message {
+	mi := &file_carabiner_signer_v1_identity_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentitySpiffe.ProtoReflect.Descriptor instead.
+func (*IdentitySpiffe) Descriptor() ([]byte, []int) {
+	return file_carabiner_signer_v1_identity_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *IdentitySpiffe) GetTrustDomain() string {
+	if x != nil {
+		return x.TrustDomain
+	}
+	return ""
+}
+
+func (x *IdentitySpiffe) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *IdentitySpiffe) GetPathRegex() string {
+	if x != nil {
+		return x.PathRegex
+	}
+	return ""
+}
+
+func (x *IdentitySpiffe) GetTrustRoots() string {
+	if x != nil {
+		return x.TrustRoots
+	}
+	return ""
+}
+
 var File_carabiner_signer_v1_identity_proto protoreflect.FileDescriptor
 
 const file_carabiner_signer_v1_identity_proto_rawDesc = "" +
 	"\n" +
-	"\"carabiner/signer/v1/identity.proto\x12\x13carabiner.signer.v1\"\xf1\x01\n" +
+	"\"carabiner/signer/v1/identity.proto\x12\x13carabiner.signer.v1\"\xbe\x02\n" +
 	"\bIdentity\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12F\n" +
 	"\bsigstore\x18\x02 \x01(\v2%.carabiner.signer.v1.IdentitySigstoreH\x00R\bsigstore\x88\x01\x01\x127\n" +
 	"\x03key\x18\x03 \x01(\v2 .carabiner.signer.v1.IdentityKeyH\x01R\x03key\x88\x01\x01\x127\n" +
-	"\x03ref\x18\x04 \x01(\v2 .carabiner.signer.v1.IdentityRefH\x02R\x03ref\x88\x01\x01B\v\n" +
+	"\x03ref\x18\x04 \x01(\v2 .carabiner.signer.v1.IdentityRefH\x02R\x03ref\x88\x01\x01\x12@\n" +
+	"\x06spiffe\x18\x05 \x01(\v2#.carabiner.signer.v1.IdentitySpiffeH\x03R\x06spiffe\x88\x01\x01B\v\n" +
 	"\t_sigstoreB\x06\n" +
 	"\x04_keyB\x06\n" +
-	"\x04_ref\"h\n" +
+	"\x04_refB\t\n" +
+	"\a_spiffe\"h\n" +
 	"\x10IdentitySigstore\x12\x17\n" +
 	"\x04mode\x18\x01 \x01(\tH\x00R\x04mode\x88\x01\x01\x12\x16\n" +
 	"\x06issuer\x18\x02 \x01(\tR\x06issuer\x12\x1a\n" +
@@ -298,7 +385,14 @@ const file_carabiner_signer_v1_identity_proto_rawDesc = "" +
 	"\x04data\x18\x03 \x01(\tR\x04data\x12/\n" +
 	"\x13signing_fingerprint\x18\x04 \x01(\tR\x12signingFingerprint\"\x1d\n" +
 	"\vIdentityRef\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02idB\xbe\x01\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x87\x01\n" +
+	"\x0eIdentitySpiffe\x12!\n" +
+	"\ftrust_domain\x18\x01 \x01(\tR\vtrustDomain\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12\x1d\n" +
+	"\n" +
+	"path_regex\x18\x03 \x01(\tR\tpathRegex\x12\x1f\n" +
+	"\vtrust_roots\x18\x04 \x01(\tR\n" +
+	"trustRootsB\xbe\x01\n" +
 	"\x17com.carabiner.signer.v1B\rIdentityProtoP\x01Z&github.com/carabiner-dev/signer/api/v1\xa2\x02\x03CSX\xaa\x02\x13Carabiner.Signer.V1\xca\x02\x13Carabiner\\Signer\\V1\xe2\x02\x1fCarabiner\\Signer\\V1\\GPBMetadata\xea\x02\x15Carabiner::Signer::V1b\x06proto3"
 
 var (
@@ -313,22 +407,24 @@ func file_carabiner_signer_v1_identity_proto_rawDescGZIP() []byte {
 	return file_carabiner_signer_v1_identity_proto_rawDescData
 }
 
-var file_carabiner_signer_v1_identity_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_carabiner_signer_v1_identity_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_carabiner_signer_v1_identity_proto_goTypes = []any{
 	(*Identity)(nil),         // 0: carabiner.signer.v1.Identity
 	(*IdentitySigstore)(nil), // 1: carabiner.signer.v1.IdentitySigstore
 	(*IdentityKey)(nil),      // 2: carabiner.signer.v1.IdentityKey
 	(*IdentityRef)(nil),      // 3: carabiner.signer.v1.IdentityRef
+	(*IdentitySpiffe)(nil),   // 4: carabiner.signer.v1.IdentitySpiffe
 }
 var file_carabiner_signer_v1_identity_proto_depIdxs = []int32{
 	1, // 0: carabiner.signer.v1.Identity.sigstore:type_name -> carabiner.signer.v1.IdentitySigstore
 	2, // 1: carabiner.signer.v1.Identity.key:type_name -> carabiner.signer.v1.IdentityKey
 	3, // 2: carabiner.signer.v1.Identity.ref:type_name -> carabiner.signer.v1.IdentityRef
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 3: carabiner.signer.v1.Identity.spiffe:type_name -> carabiner.signer.v1.IdentitySpiffe
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_carabiner_signer_v1_identity_proto_init() }
@@ -344,7 +440,7 @@ func file_carabiner_signer_v1_identity_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_carabiner_signer_v1_identity_proto_rawDesc), len(file_carabiner_signer_v1_identity_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/v1/identity_test.go
+++ b/api/v1/identity_test.go
@@ -4,12 +4,46 @@
 package v1
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/carabiner-dev/signer/key"
 )
+
+// mintSpiffeLeafForTest mints a self-signed cert whose URI SAN is the given
+// spiffe:// ID. Good enough for IdentitySpiffeFromCert unit tests.
+func mintSpiffeLeafForTest(t *testing.T, spiffeURI string) *x509.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	uri, err := url.Parse(spiffeURI)
+	require.NoError(t, err)
+	tpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "svid"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	if uri != nil && uri.Scheme != "" {
+		tpl.URIs = []*url.URL{uri}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
 
 func TestVerifyIdentity(t *testing.T) {
 	t.Parallel()
@@ -66,6 +100,91 @@ func TestVerifyIdentity(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestIdentitySpiffeFromString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success-with-path", func(t *testing.T) {
+		t.Parallel()
+		id, err := IdentitySpiffeFromString("spiffe://prod.example.org/workload/api")
+		require.NoError(t, err)
+		require.Equal(t, "prod.example.org", id.GetTrustDomain())
+		require.Equal(t, "/workload/api", id.GetPath())
+		require.Empty(t, id.GetTrustRoots())
+		require.Empty(t, id.GetPathRegex())
+	})
+
+	t.Run("success-no-path", func(t *testing.T) {
+		t.Parallel()
+		id, err := IdentitySpiffeFromString("spiffe://example.org")
+		require.NoError(t, err)
+		require.Equal(t, "example.org", id.GetTrustDomain())
+		require.Empty(t, id.GetPath())
+	})
+
+	t.Run("invalid-scheme", func(t *testing.T) {
+		t.Parallel()
+		_, err := IdentitySpiffeFromString("https://example.org/workload")
+		require.Error(t, err)
+	})
+
+	t.Run("empty-string", func(t *testing.T) {
+		t.Parallel()
+		_, err := IdentitySpiffeFromString("")
+		require.Error(t, err)
+	})
+
+	t.Run("missing-trust-domain", func(t *testing.T) {
+		t.Parallel()
+		_, err := IdentitySpiffeFromString("spiffe:///workload")
+		require.Error(t, err)
+	})
+}
+
+func TestIdentitySpiffeFromCert(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		leaf := mintSpiffeLeafForTest(t, "spiffe://prod.example.org/workload/api")
+		id, err := IdentitySpiffeFromCert(leaf)
+		require.NoError(t, err)
+		require.Equal(t, "prod.example.org", id.GetTrustDomain())
+		require.Equal(t, "/workload/api", id.GetPath())
+		require.Empty(t, id.GetTrustRoots(), "TrustRoots must not be populated on the verified-side identity")
+		require.Empty(t, id.GetPathRegex())
+	})
+
+	t.Run("nil-cert", func(t *testing.T) {
+		t.Parallel()
+		_, err := IdentitySpiffeFromCert(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("cert-with-no-uri-san", func(t *testing.T) {
+		t.Parallel()
+		leaf := mintSpiffeLeafForTest(t, "")
+		_, err := IdentitySpiffeFromCert(leaf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "spiffe://")
+	})
+
+	t.Run("cert-with-non-spiffe-uri-san", func(t *testing.T) {
+		t.Parallel()
+		leaf := mintSpiffeLeafForTest(t, "https://example.com/workload")
+		_, err := IdentitySpiffeFromCert(leaf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "spiffe://")
+	})
+
+	t.Run("cert-with-malformed-spiffe-uri", func(t *testing.T) {
+		t.Parallel()
+		// Valid URI scheme but not a valid SPIFFE ID (empty trust domain).
+		leaf := mintSpiffeLeafForTest(t, "spiffe:///workload")
+		_, err := IdentitySpiffeFromCert(leaf)
+		require.Error(t, err)
+	})
 }
 
 func TestIdentityKeyFromPublic(t *testing.T) {

--- a/api/v1/verification.go
+++ b/api/v1/verification.go
@@ -8,11 +8,56 @@ import (
 	"strings"
 
 	"github.com/carabiner-dev/attestation"
+	"github.com/sigstore/sigstore-go/pkg/verify"
 	"google.golang.org/protobuf/proto"
 )
 
 // Ensure we are implementing the framworks verification
 var _ attestation.Verification = (*Verification)(nil) //nolint:errcheck
+
+// SignatureVerificationFromResult translates sigstore-go's
+// *verify.VerificationResult into the api/v1 SignatureVerification used for
+// policy matching. Handles both sigstore and SPIFFE flows by inspecting
+// VerifiedIdentity: a spiffe:// SAN produces an IdentitySpiffe; any other
+// SAN/Issuer pair produces an IdentitySigstore.
+//
+// Pass a nil result (e.g. when verification failed) to get back an empty,
+// unverified SignatureVerification. Callers typically invoke this after a
+// successful Verify call:
+//
+//	result, err := verifier.Verify(nil, bndl)
+//	if err != nil {
+//	    return err
+//	}
+//	sv := api.SignatureVerificationFromResult(result)
+//	if !sv.MatchesIdentity(policyIdentity) {
+//	    return errors.New("signer not authorized by policy")
+//	}
+func SignatureVerificationFromResult(r *verify.VerificationResult) *SignatureVerification {
+	if r == nil {
+		return &SignatureVerification{}
+	}
+	sv := &SignatureVerification{Verified: true}
+	if r.VerifiedIdentity == nil {
+		return sv
+	}
+	san := r.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName
+	issuer := r.VerifiedIdentity.Issuer.Issuer
+
+	switch {
+	case strings.HasPrefix(san, "spiffe://"):
+		id, err := IdentitySpiffeFromString(san)
+		if err != nil {
+			return sv
+		}
+		sv.Identities = append(sv.Identities, &Identity{Spiffe: id})
+	case san != "" || issuer != "":
+		sv.Identities = append(sv.Identities, &Identity{
+			Sigstore: &IdentitySigstore{Issuer: issuer, Identity: san},
+		})
+	}
+	return sv
+}
 
 // Error implements the Go error interface when verification fails
 func (v *Verification) Error() string {
@@ -51,6 +96,8 @@ func (sv *SignatureVerification) MatchesIdentity(id *Identity) bool {
 		return sv.MatchesSigstoreIdentity(id.GetSigstore())
 	case id.GetKey() != nil:
 		return sv.MatchesKeyIdentity(id.GetKey())
+	case id.GetSpiffe() != nil:
+		return sv.MatchesSpiffeIdentity(id.GetSpiffe())
 	default:
 		return false //  This would be an error
 	}
@@ -96,6 +143,63 @@ func (sv *SignatureVerification) MatchesSigstoreIdentity(id *IdentitySigstore) b
 				return true
 			}
 		}
+	}
+	return false
+}
+
+// MatchesSpiffeIdentity returns true if one of the verified signatures was
+// produced by a SPIFFE workload matching the supplied identity. Matching
+// rules:
+//
+//   - TrustDomain (required): compared exactly against the signer's trust
+//     domain. An empty TrustDomain in the policy is rejected since a
+//     wildcard match across trust domains is almost never the intent.
+//   - Path (optional): when set, the signer's SPIFFE path must match
+//     exactly. Mutually exclusive with PathRegex.
+//   - PathRegex (optional): when set, compiled and applied to the signer's
+//     SPIFFE path. Mutually exclusive with Path.
+//   - TrustRoots is not consulted here — it is policy configuration used
+//     by the verifier to validate the chain, not an attribute of the
+//     signer.
+//
+// If both Path and PathRegex are set the policy is treated as malformed
+// and no match is returned.
+func (sv *SignatureVerification) MatchesSpiffeIdentity(id *IdentitySpiffe) bool {
+	if id.GetTrustDomain() == "" {
+		return false
+	}
+	if id.GetPath() != "" && id.GetPathRegex() != "" {
+		return false
+	}
+
+	var pathRegex *regexp.Regexp
+	if id.GetPathRegex() != "" {
+		re, err := regexp.Compile(id.GetPathRegex())
+		if err != nil {
+			return false
+		}
+		pathRegex = re
+	}
+
+	for _, signer := range sv.GetIdentities() {
+		signerSpiffe := signer.GetSpiffe()
+		if signerSpiffe == nil {
+			continue
+		}
+		if signerSpiffe.GetTrustDomain() != id.GetTrustDomain() {
+			continue
+		}
+		switch {
+		case id.GetPath() != "":
+			if signerSpiffe.GetPath() != id.GetPath() {
+				continue
+			}
+		case pathRegex != nil:
+			if !pathRegex.MatchString(signerSpiffe.GetPath()) {
+				continue
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/api/v1/verification_test.go
+++ b/api/v1/verification_test.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/require"
 )
 
@@ -196,6 +197,203 @@ func TestMatchesKeyIdentity(t *testing.T) {
 			require.Equal(t, tt.matches, tt.sut.MatchesKeyIdentity(tt.id))
 		})
 	}
+}
+
+func TestMatchesSpiffeIdentity(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		matches bool
+		sut     *SignatureVerification
+		id      *IdentitySpiffe
+	}{
+		{
+			"td-and-path-exact-match", true,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"},
+		},
+		{
+			"td-only-matches-any-path", true,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org"},
+		},
+		{
+			"td-mismatch", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "other.example", Path: "/workload"},
+		},
+		{
+			"path-mismatch", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", Path: "/other"},
+		},
+		{
+			"path-regex-match", true,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload/api"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", PathRegex: `^/workload/.*$`},
+		},
+		{
+			"path-regex-no-match", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload/api"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", PathRegex: `^/other/.*$`},
+		},
+		{
+			"empty-trust-domain-rejected", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{Path: "/workload"},
+		},
+		{
+			"path-and-regex-both-set-rejected", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", Path: "/workload", PathRegex: `.*`},
+		},
+		{
+			"invalid-regex-rejected", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", PathRegex: `[invalid`},
+		},
+		{
+			"non-spiffe-signer-ignored", false,
+			&SignatureVerification{
+				Identities: []*Identity{{Key: &IdentityKey{Id: "1234abc"}}},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org"},
+		},
+		{
+			"two-signers-second-matches", true,
+			&SignatureVerification{
+				Identities: []*Identity{
+					{Spiffe: &IdentitySpiffe{TrustDomain: "other.example", Path: "/a"}},
+					{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/b"}},
+				},
+			},
+			&IdentitySpiffe{TrustDomain: "example.org", Path: "/b"},
+		},
+		{
+			// trust_roots on the policy side is ignored for matching — it's
+			// verifier config, not a signer attribute.
+			"trust-roots-ignored-for-matching", true,
+			&SignatureVerification{
+				Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+			},
+			&IdentitySpiffe{
+				TrustDomain: "example.org",
+				Path:        "/workload",
+				TrustRoots:  "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+			},
+		},
+		{
+			"empty-identities", false,
+			&SignatureVerification{Identities: []*Identity{}},
+			&IdentitySpiffe{TrustDomain: "example.org"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.matches, tt.sut.MatchesSpiffeIdentity(tt.id))
+		})
+	}
+}
+
+func TestSignatureVerificationFromResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil-result-unverified", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(nil)
+		require.False(t, sv.GetVerified())
+		require.Empty(t, sv.GetIdentities())
+	})
+
+	t.Run("spiffe-san-produces-spiffe-identity", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{
+			VerifiedIdentity: &verify.CertificateIdentity{
+				SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: "spiffe://example.org/workload",
+				},
+			},
+		})
+		require.True(t, sv.GetVerified())
+		require.Len(t, sv.GetIdentities(), 1)
+		spiffe := sv.GetIdentities()[0].GetSpiffe()
+		require.NotNil(t, spiffe)
+		require.Equal(t, "example.org", spiffe.GetTrustDomain())
+		require.Equal(t, "/workload", spiffe.GetPath())
+	})
+
+	t.Run("fulcio-identity-produces-sigstore-identity", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{
+			VerifiedIdentity: &verify.CertificateIdentity{
+				SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: "user@example.com",
+				},
+				Issuer: verify.IssuerMatcher{Issuer: "https://accounts.google.com"},
+			},
+		})
+		require.True(t, sv.GetVerified())
+		require.Len(t, sv.GetIdentities(), 1)
+		ss := sv.GetIdentities()[0].GetSigstore()
+		require.NotNil(t, ss)
+		require.Equal(t, "https://accounts.google.com", ss.GetIssuer())
+		require.Equal(t, "user@example.com", ss.GetIdentity())
+	})
+
+	t.Run("result-without-verified-identity", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{})
+		require.True(t, sv.GetVerified())
+		require.Empty(t, sv.GetIdentities())
+	})
+
+	t.Run("malformed-spiffe-san-falls-through-to-empty", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{
+			VerifiedIdentity: &verify.CertificateIdentity{
+				SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: "spiffe:///workload", // missing trust domain
+				},
+			},
+		})
+		// Verified stays true (the cryptographic verification succeeded)
+		// but no identity was extractable.
+		require.True(t, sv.GetVerified())
+		require.Empty(t, sv.GetIdentities())
+	})
+}
+
+// TestMatchesIdentityDispatchesSpiffe confirms the top-level dispatcher
+// routes SPIFFE-shaped identities to MatchesSpiffeIdentity.
+func TestMatchesIdentityDispatchesSpiffe(t *testing.T) {
+	t.Parallel()
+	sv := &SignatureVerification{
+		Identities: []*Identity{{Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"}}},
+	}
+	require.True(t, sv.MatchesIdentity(&Identity{
+		Spiffe: &IdentitySpiffe{TrustDomain: "example.org", Path: "/workload"},
+	}))
+	require.False(t, sv.MatchesIdentity(&Identity{
+		Spiffe: &IdentitySpiffe{TrustDomain: "other.example"},
+	}))
 }
 
 func TestMatchesKeyIdentityDoesNotMutate(t *testing.T) {

--- a/proto/carabiner/signer/v1/identity.proto
+++ b/proto/carabiner/signer/v1/identity.proto
@@ -10,11 +10,13 @@ option go_package = "github.com/carabiner-dev/signer/api/v1";
 //   a) A sigstore identity
 //   b) A key
 //   c) A reference to an identity defined outside the policy
+//   d) A SPIFFE identity
 message Identity {
     string id = 1;
     optional IdentitySigstore sigstore = 2;
     optional IdentityKey key = 3;
     optional IdentityRef ref = 4;
+    optional IdentitySpiffe spiffe = 5;
 }
 
 // IdentitySigstore represents the identity data in a Fulcio cert.
@@ -34,7 +36,22 @@ message IdentityKey {
 
 // IdentityRef represents an identity defined outside of the policy. Most commonly
 // these identities will be defined at the policy set level to have a common
-// definition that can be reused by all policies in a set. 
+// definition that can be reused by all policies in a set.
 message IdentityRef {
     string id = 1;
+}
+
+// IdentitySpiffe matches signatures produced by a SPIFFE workload. The
+// trust_domain is required; path / path_regex are optional matchers on the
+// SVID's SPIFFE path component (mutually exclusive).
+//
+// trust_roots inlines the PEM-encoded SPIRE upstream CA root(s) used to
+// validate the SVID chain, analogous to IdentityKey.data. Unlike the sigstore
+// flow there is no universal trust-root registry for SPIFFE, so the policy
+// must carry (or reference) the anchor itself.
+message IdentitySpiffe {
+    string trust_domain = 1;
+    string path = 2;
+    string path_regex = 3;
+    string trust_roots = 4;
 }

--- a/spiffe/verifier.go
+++ b/spiffe/verifier.go
@@ -17,6 +17,7 @@ import (
 
 	intoto "github.com/in-toto/attestation/go/v1"
 	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -148,7 +149,7 @@ func (v *Verifier) Verify(_ *options.Verification, bndl *sbundle.Bundle) (*verif
 		return nil, fmt.Errorf("verifying dsse signature: %w", err)
 	}
 
-	return buildResult(bndl), nil
+	return buildResult(bndl, leaf, id), nil
 }
 
 func (v *Verifier) matchIdentity(id spiffeid.ID) error {
@@ -257,11 +258,35 @@ func verifyWithKey(pub crypto.PublicKey, msg, sig []byte) error {
 	}
 }
 
-// buildResult constructs a best-effort VerificationResult. Tries to parse the
-// DSSE payload as an in-toto Statement and populate it; leaves timestamps and
-// transparency-log fields empty (SPIFFE signatures don't produce them).
-func buildResult(bndl *sbundle.Bundle) *verify.VerificationResult {
+// buildResult constructs a best-effort VerificationResult. Populates:
+//   - MediaType (via NewVerificationResult)
+//   - Statement  — when the DSSE payload is a valid in-toto Statement
+//   - Signature.Certificate — a SummarizeCertificate of the SVID leaf. The
+//     Summary's SubjectAlternativeName will carry the SPIFFE ID since it's
+//     the leaf's first URI SAN.
+//   - VerifiedIdentity.SubjectAlternativeName — the SPIFFE ID. Lets callers
+//     read the verified signer using the same sigstore-go result fields the
+//     sigstore path populates.
+//
+// Transparency-log and TSA fields are intentionally left empty; SPIFFE
+// signatures don't produce them.
+func buildResult(bndl *sbundle.Bundle, leaf *x509.Certificate, id spiffeid.ID) *verify.VerificationResult {
 	result := verify.NewVerificationResult()
+
+	// Attach the leaf summary and the verified SPIFFE ID. Populating both
+	// keeps parity with how sigstore-go's own verifier fills these fields
+	// for Fulcio signatures.
+	if summary, err := certificate.SummarizeCertificate(leaf); err == nil {
+		result.Signature = &verify.SignatureVerificationResult{
+			Certificate: &summary,
+		}
+	}
+	result.VerifiedIdentity = &verify.CertificateIdentity{
+		SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+			SubjectAlternativeName: id.String(),
+		},
+	}
+
 	env := bndl.GetDsseEnvelope()
 	if env == nil || len(env.GetPayload()) == 0 {
 		return result

--- a/spiffe/verifier_test.go
+++ b/spiffe/verifier_test.go
@@ -139,6 +139,20 @@ func TestVerifierSuccess(t *testing.T) {
 	result, err := v.Verify(nil, bndl)
 	require.NoError(t, err)
 	require.NotNil(t, result)
+
+	// Verified identity carries the SPIFFE ID as its SAN.
+	require.NotNil(t, result.VerifiedIdentity)
+	require.Equal(t, "spiffe://example.org/workload",
+		result.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName)
+
+	// Signature summary carries the leaf summary, including the SPIFFE ID.
+	require.NotNil(t, result.Signature)
+	require.NotNil(t, result.Signature.Certificate)
+	require.Equal(t, "spiffe://example.org/workload",
+		result.Signature.Certificate.SubjectAlternativeName)
+
+	// The in-toto payload was parsed into result.Statement.
+	require.NotNil(t, result.Statement)
 }
 
 func TestVerifierFromOptionsViaPEM(t *testing.T) {


### PR DESCRIPTION
This pull request adds first-class support for SPIFFE identities to the API, enabling the system to recognize, parse, and match SPIFFE-based signers alongside existing identity types. The changes introduce a new `IdentitySpiffe` type, extend the identity matching logic, and provide robust helpers and tests for working with SPIFFE IDs.

**SPIFFE identity support:**

* Added a new `IdentitySpiffe` message to the API, with fields for `trust_domain`, `path`, `path_regex`, and `trust_roots`, and included it as a oneof option in the main `Identity` message. [[1]](diffhunk://#diff-e4643b991bb1bf857fbae2c1b9a2b084147b68146ce65ae047835f90e93a46c7R32-R39) [[2]](diffhunk://#diff-e4643b991bb1bf857fbae2c1b9a2b084147b68146ce65ae047835f90e93a46c7R286-R376) [[3]](diffhunk://#diff-e4643b991bb1bf857fbae2c1b9a2b084147b68146ce65ae047835f90e93a46c7L301-R395) [[4]](diffhunk://#diff-e4643b991bb1bf857fbae2c1b9a2b084147b68146ce65ae047835f90e93a46c7L316-R427) [[5]](diffhunk://#diff-e4643b991bb1bf857fbae2c1b9a2b084147b68146ce65ae047835f90e93a46c7L347-R443)
* Implemented `IdentitySpiffeFromString` and `IdentitySpiffeFromCert` helpers to parse and construct `IdentitySpiffe` objects from SPIFFE ID strings and X.509 certificates, respectively.
* Added a new matcher, `MatchesSpiffeIdentity`, to `SignatureVerification`, and extended the main identity matching logic to support SPIFFE identities. [[1]](diffhunk://#diff-2653afac8b841a60af5f1eb9cdc9bccf2afa04ad2f9dffe2bc660fcb4da68b55R99-R100) [[2]](diffhunk://#diff-2653afac8b841a60af5f1eb9cdc9bccf2afa04ad2f9dffe2bc660fcb4da68b55R150-R206)

**Integration with verification flow:**

* Enhanced the signature verification result translation (`SignatureVerificationFromResult`) to recognize and populate SPIFFE identities from sigstore-go verification results.

**Testing and utilities:**

* Added comprehensive unit tests for SPIFFE identity parsing, certificate extraction, and matching logic, including a helper to mint test certificates with SPIFFE URI SANs. [[1]](diffhunk://#diff-44516879e61de64276bacfb61c9d3ba0b777e4eceaac1064894fe876db0e9403R7-R47) [[2]](diffhunk://#diff-44516879e61de64276bacfb61c9d3ba0b777e4eceaac1064894fe876db0e9403R105-R189)
* Updated imports to include necessary dependencies for SPIFFE and sigstore verification. [[1]](diffhunk://#diff-8be46464b365be1c4e40585a63e98e73eefc72cc9e62a78507656b8be2cb4b65R7-R13) [[2]](diffhunk://#diff-b8cd34350721a8d2034ca58f651e1442623771331c460c200f0c02f11dc9eb07R9) [[3]](diffhunk://#diff-2653afac8b841a60af5f1eb9cdc9bccf2afa04ad2f9dffe2bc660fcb4da68b55R11-R61)

These changes collectively enable robust SPIFFE identity support in both policy and verification workflows.