### PR TITLE
Add spiffe e2e tests using spire server

### DIFF
--- a/.github/workflows/go-build-and-test.yaml
+++ b/.github/workflows/go-build-and-test.yaml
@@ -66,6 +66,43 @@ jobs:
         go get -d ./...
         go test -v ./...
 
+  spire:
+    needs: go-versions
+    name: SPIFFE E2E Tests (SPIRE fixture)
+    # Linux-only: hack/spire uses `pid: host` in docker-compose, and only
+    # Linux runners have Docker pre-installed. No secrets/OIDC needed, so
+    # this runs on fork PRs too — the fixture is fully local.
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: ${{ needs.go-versions.outputs.stable }}
+        check-latest: true
+        cache: true
+
+    - name: Start SPIRE fixture
+      run: make spire-up
+
+    - name: Run SPIFFE E2E tests
+      run: make spiffe-tests
+
+    - name: Dump SPIRE logs on failure
+      if: failure()
+      run: cd hack/spire && docker compose logs --no-color --tail=200
+
+    - name: Tear down SPIRE fixture
+      if: always()
+      run: make spire-down
+
   e2e:
     needs: go-versions
     name: E2E Tests (go ${{ matrix.go-version }}, ${{ matrix.os }})

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,21 @@ fakes: ## Rebuild the implementation fakes
 .PHONY: proto
 proto: ## Rebuild the code from the protobuf definitions
 	hack/generate-protos.sh
+
+.PHONY: spire-up
+spire-up: ## Start a local SPIRE server+agent fixture for e2e tests
+	hack/spire/up.sh
+
+.PHONY: spire-down
+spire-down: ## Tear down the local SPIRE fixture
+	hack/spire/down.sh
+
+.PHONY: spire-logs
+spire-logs: ## Follow logs from the local SPIRE server+agent
+	cd hack/spire && docker compose logs -f
+
+.PHONY: spiffe-tests
+spiffe-tests: ## Run the SPIFFE end-to-end tests against the local fixture (spire-up first)
+	SPIFFE_ENDPOINT_SOCKET="unix://$(CURDIR)/hack/spire/socket/api.sock" \
+	SPIFFE_TRUST_BUNDLE="$(CURDIR)/hack/spire/bundle.pem" \
+	go test -tags=e2e -v ./spiffe/...

--- a/hack/spire/.gitignore
+++ b/hack/spire/.gitignore
@@ -1,0 +1,3 @@
+upstream-ca/
+socket/
+bundle.pem

--- a/hack/spire/agent.conf
+++ b/hack/spire/agent.conf
@@ -1,0 +1,26 @@
+agent {
+    data_dir = "/tmp/spire-agent"
+    log_level = "INFO"
+    server_address = "spire-server"
+    server_port = "8081"
+    socket_path = "/tmp/spire-agent/public/api.sock"
+    trust_domain = "test.local"
+
+    # Test-only: accept the server's bootstrap bundle without out-of-band
+    # verification. Fine for a local fixture; do not copy this into prod.
+    insecure_bootstrap = true
+}
+
+plugins {
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    KeyManager "memory" {
+        plugin_data {}
+    }
+
+    WorkloadAttestor "unix" {
+        plugin_data {}
+    }
+}

--- a/hack/spire/docker-compose.yml
+++ b/hack/spire/docker-compose.yml
@@ -1,0 +1,46 @@
+# Local SPIRE fixture for running the SPIFFE end-to-end tests.
+# See hack/spire/up.sh for orchestration — docker compose alone can't
+# bootstrap this because the agent needs a join token generated after the
+# server starts.
+
+services:
+  spire-server:
+    image: ghcr.io/spiffe/spire-server:${SPIRE_VERSION:-1.10.4}
+    container_name: carabiner-signer-spire-server
+    command: ["-config", "/opt/spire/conf/server/server.conf"]
+    volumes:
+      - ./server.conf:/opt/spire/conf/server/server.conf:ro
+      - ./upstream-ca:/opt/spire/upstream-ca:ro
+    networks:
+      - spire
+    healthcheck:
+      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  spire-agent:
+    image: ghcr.io/spiffe/spire-agent:${SPIRE_VERSION:-1.10.4}
+    container_name: carabiner-signer-spire-agent
+    # Share the host PID namespace so the unix workload attestor can read
+    # /proc/<pid> for host processes connecting to the mounted socket.
+    # Without this, the agent logs "could not resolve caller information"
+    # on every attestation attempt from the host. Test fixture only.
+    pid: host
+    command:
+      - "-config"
+      - "/opt/spire/conf/agent/agent.conf"
+      - "-joinToken"
+      - "${SPIRE_JOIN_TOKEN:-}"
+    volumes:
+      - ./agent.conf:/opt/spire/conf/agent/agent.conf:ro
+      - ./socket:/tmp/spire-agent/public
+    depends_on:
+      spire-server:
+        condition: service_healthy
+    networks:
+      - spire
+
+networks:
+  spire:
+    name: carabiner-signer-spire

--- a/hack/spire/down.sh
+++ b/hack/spire/down.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tear down the local SPIRE fixture. Leaves the upstream CA material in
+# place so a subsequent `up.sh` reuses the same trust anchor (and therefore
+# the same bundle.pem). Delete hack/spire/upstream-ca by hand if you want a
+# fresh root.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+echo "==> Stopping spire-agent and spire-server"
+docker compose down --volumes --remove-orphans
+
+echo "==> Cleaning runtime artifacts"
+rm -f socket/api.sock bundle.pem
+rmdir socket 2>/dev/null || true
+
+echo "SPIRE fixture torn down. upstream-ca/ preserved for next run."

--- a/hack/spire/server.conf
+++ b/hack/spire/server.conf
@@ -1,0 +1,44 @@
+server {
+    bind_address = "0.0.0.0"
+    bind_port = "8081"
+    trust_domain = "test.local"
+    # /tmp is writable by the non-root `spire` user in the official image;
+    # persistent state isn't needed for the test fixture.
+    data_dir = "/tmp/spire-server"
+    log_level = "INFO"
+    ca_subject = {
+        country = ["US"]
+        organization = ["carabiner-signer-tests"]
+        common_name = "spire-server-ca"
+    }
+    # Shorten to exercise rotation-ish semantics without being flaky in tests.
+    default_x509_svid_ttl = "10m"
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "/tmp/spire-server/datastore.sqlite3"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    KeyManager "memory" {
+        plugin_data {}
+    }
+
+    # UpstreamAuthority with a disk-backed CA gives us a non-trivial chain:
+    # the SVID leaf is signed by the server's intermediate, which is signed
+    # by this disk CA. That exercises PR 3's intermediate-chain embedding
+    # and PR 4's chain-validation-with-intermediates path end-to-end.
+    UpstreamAuthority "disk" {
+        plugin_data {
+            cert_file_path = "/opt/spire/upstream-ca/ca.pem"
+            key_file_path  = "/opt/spire/upstream-ca/ca-key.pem"
+        }
+    }
+}

--- a/hack/spire/up.sh
+++ b/hack/spire/up.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+#
+# Boot a local SPIRE server + agent and register this user's UID as a
+# workload. Produces:
+#   hack/spire/socket/api.sock  — agent Workload API socket
+#   hack/spire/bundle.pem       — pinned trust root for the verifier
+#
+# Upstream CA material is generated on first run under hack/spire/upstream-ca
+# and reused on subsequent runs, so teardown/up loops don't invalidate the
+# exported bundle.pem unless you blow the CA away manually.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+AGENT_SPIFFE_ID="spiffe://test.local/agent/test"
+WORKLOAD_SPIFFE_ID="spiffe://test.local/workload"
+
+echo "==> Preparing upstream CA"
+if [[ ! -f upstream-ca/ca.pem ]]; then
+    mkdir -p upstream-ca
+    openssl ecparam -name prime256v1 -genkey -noout -out upstream-ca/ca-key.pem
+    openssl req -new -x509 -days 3650 \
+        -key upstream-ca/ca-key.pem \
+        -out upstream-ca/ca.pem \
+        -subj "/CN=carabiner-signer-test-upstream-ca" \
+        -addext "basicConstraints=critical,CA:TRUE,pathlen:1" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign"
+    echo "    generated fresh upstream CA in upstream-ca/"
+else
+    echo "    reusing existing upstream CA at upstream-ca/ca.pem"
+fi
+
+echo "==> Preparing socket directory"
+mkdir -p socket
+# The agent runs as the non-root `spire` user inside the container. When
+# Docker bind-mounts this host dir, UIDs don't line up, so open the
+# permissions wide for the test fixture. Also clear any stale socket from
+# a previous run so the `until [ -S ... ]` wait below is against the
+# current boot, not a leftover file.
+chmod 0777 socket
+rm -f socket/api.sock
+
+echo "==> Starting spire-server"
+docker compose up -d spire-server
+
+echo "==> Waiting for server healthcheck"
+for _ in $(seq 1 30); do
+    if docker compose exec -T spire-server /opt/spire/bin/spire-server healthcheck >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+if ! docker compose exec -T spire-server /opt/spire/bin/spire-server healthcheck >/dev/null 2>&1; then
+    echo "    server never became healthy; check 'make spire-logs'" >&2
+    exit 1
+fi
+
+echo "==> Generating join token for the agent"
+TOKEN_OUTPUT=$(docker compose exec -T spire-server /opt/spire/bin/spire-server token generate \
+    -spiffeID "${AGENT_SPIFFE_ID}")
+# Output looks like: "Token: <hex>"
+TOKEN=$(echo "${TOKEN_OUTPUT}" | awk -F': ' '/^Token:/ {print $2}' | tr -d '[:space:]')
+if [[ -z "${TOKEN}" ]]; then
+    echo "    failed to parse join token from: ${TOKEN_OUTPUT}" >&2
+    exit 1
+fi
+
+echo "==> Starting spire-agent"
+SPIRE_JOIN_TOKEN="${TOKEN}" docker compose up -d spire-agent
+
+echo "==> Waiting for agent Workload API socket"
+for _ in $(seq 1 60); do
+    if [[ -S socket/api.sock ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ! -S socket/api.sock ]]; then
+    echo "    agent never exposed its Workload API socket; check 'make spire-logs'" >&2
+    exit 1
+fi
+
+echo "==> Registering workload entry for UID $(id -u)"
+docker compose exec -T spire-server /opt/spire/bin/spire-server entry create \
+    -parentID "${AGENT_SPIFFE_ID}" \
+    -spiffeID "${WORKLOAD_SPIFFE_ID}" \
+    -selector "unix:uid:$(id -u)" >/dev/null
+
+echo "==> Exporting trust bundle"
+docker compose exec -T spire-server /opt/spire/bin/spire-server bundle show -format pem > bundle.pem
+
+echo ""
+echo "SPIRE is up."
+echo "  socket:       ${SCRIPT_DIR}/socket/api.sock"
+echo "  trust bundle: ${SCRIPT_DIR}/bundle.pem"
+echo "  workload SVID: ${WORKLOAD_SPIFFE_ID}"
+echo ""
+echo "Run 'make spiffe-tests' to exercise the end-to-end flow."

--- a/hack/spire/up.sh
+++ b/hack/spire/up.sh
@@ -31,6 +31,12 @@ if [[ ! -f upstream-ca/ca.pem ]]; then
         -subj "/CN=carabiner-signer-test-upstream-ca" \
         -addext "basicConstraints=critical,CA:TRUE,pathlen:1" \
         -addext "keyUsage=critical,keyCertSign,cRLSign"
+    # The spire-server container runs as a non-root `spire` user. When we
+    # bind-mount this directory the in-container UID won't match the host
+    # user that just generated these files, so openssl's default 0600 key
+    # mode prevents SPIRE from loading it. Test-fixture CA; not a secret
+    # worth protecting with tight perms.
+    chmod 0644 upstream-ca/ca-key.pem upstream-ca/ca.pem
     echo "    generated fresh upstream CA in upstream-ca/"
 else
     echo "    reusing existing upstream CA at upstream-ca/ca.pem"

--- a/spiffe/e2e_test.go
+++ b/spiffe/e2e_test.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package spiffe_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/stretchr/testify/require"
+
+	signerlib "github.com/carabiner-dev/signer"
+	api "github.com/carabiner-dev/signer/api/v1"
+	"github.com/carabiner-dev/signer/options"
+	"github.com/carabiner-dev/signer/spiffe"
+)
+
+// TestE2ESPIFFESignAndVerify exercises the full SPIFFE pipeline against a
+// real SPIRE fixture:
+//
+//   - talk to spire-agent over the Workload API socket
+//   - sign an in-toto statement with the issued SVID
+//   - assert the resulting bundle carries a leaf + intermediate (the
+//     fixture's UpstreamAuthority produces a non-trivial chain)
+//   - verify the bundle against the exported upstream CA
+//   - translate the verification result into api/v1.SignatureVerification
+//     and match the SPIFFE identity
+//
+// Requires `make spire-up` to have run first; skipped otherwise.
+func TestE2ESPIFFESignAndVerify(t *testing.T) {
+	socketAddr := os.Getenv("SPIFFE_ENDPOINT_SOCKET")
+	bundlePath := os.Getenv("SPIFFE_TRUST_BUNDLE")
+	if socketAddr == "" || bundlePath == "" {
+		t.Skip("SPIFFE_ENDPOINT_SOCKET / SPIFFE_TRUST_BUNDLE unset — run `make spire-up` first")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	source, err := workloadapi.NewX509Source(ctx,
+		workloadapi.WithClientOptions(workloadapi.WithAddr(socketAddr)))
+	require.NoError(t, err, "connecting to the Workload API")
+	t.Cleanup(func() {
+		if cerr := source.Close(); cerr != nil {
+			t.Logf("closing workload API source: %v", cerr)
+		}
+	})
+
+	// Sanity check before signing: the agent actually gave us an SVID.
+	svid, err := source.GetX509SVID()
+	require.NoError(t, err, "fetching initial SVID")
+	require.NotNil(t, svid)
+	require.Equal(t, "test.local", svid.ID.TrustDomain().Name())
+	require.Equal(t, "/workload", svid.ID.Path())
+
+	// Sign
+	signer := signerlib.NewSigner()
+	signer.Credentials = &spiffe.CredentialProvider{Source: source}
+	statement := []byte(`{` +
+		`"_type":"https://in-toto.io/Statement/v1",` +
+		`"subject":[{"name":"e2e","digest":{"sha256":"0000000000000000000000000000000000000000000000000000000000000000"}}],` +
+		`"predicateType":"https://example.com/p/v1",` +
+		`"predicate":{}` +
+		`}`)
+	bndl, err := signer.SignStatement(statement)
+	require.NoError(t, err, "signing statement")
+	require.NotNil(t, bndl)
+
+	// The UpstreamAuthority chain means the SVID has at least [leaf,
+	// intermediate] — assert the bundle carried that through.
+	chain, ok := bndl.Bundle.GetVerificationMaterial().GetContent().(*protobundle.VerificationMaterial_X509CertificateChain)
+	require.True(t, ok, "expected X509CertificateChain content (UpstreamAuthority produces intermediates), got %T",
+		bndl.Bundle.GetVerificationMaterial().GetContent())
+	require.GreaterOrEqual(t, len(chain.X509CertificateChain.GetCertificates()), 2,
+		"expected at least leaf + intermediate in chain")
+
+	// Verify against the pinned upstream root.
+	verifier := signerlib.NewVerifier(func(v *options.Verifier) {
+		v.TrustRootsPath = bundlePath
+	})
+	result, err := verifier.VerifyParsedBundle(bndl)
+	require.NoError(t, err, "verifying bundle")
+	require.NotNil(t, result)
+	require.NotNil(t, result.VerifiedIdentity)
+	require.Equal(t, "spiffe://test.local/workload",
+		result.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName)
+
+	// Policy matching via the api/v1 layer.
+	sv := api.SignatureVerificationFromResult(result)
+	require.True(t, sv.GetVerified())
+
+	require.True(t, sv.MatchesIdentity(&api.Identity{
+		Spiffe: &api.IdentitySpiffe{
+			TrustDomain: "test.local",
+			Path:        "/workload",
+		},
+	}), "policy matching the issued SVID should succeed")
+
+	require.False(t, sv.MatchesIdentity(&api.Identity{
+		Spiffe: &api.IdentitySpiffe{
+			TrustDomain: "other.example",
+		},
+	}), "policy with wrong trust domain should not match")
+
+	require.True(t, sv.MatchesIdentity(&api.Identity{
+		Spiffe: &api.IdentitySpiffe{
+			TrustDomain: "test.local",
+			PathRegex:   `^/work.*$`,
+		},
+	}), "regex policy should match")
+}


### PR DESCRIPTION
This pull request introduces a local SPIRE (SPIFFE Runtime Environment) fixture and a corresponding end-to-end (E2E) test for the SPIFFE integration. The changes enable automated, repeatable SPIFFE-based signing and verification tests in CI and local development, using a real SPIRE server and agent running in Docker. The implementation includes new Makefile targets, workflow automation, configuration files, and a comprehensive E2E test that exercises the full SPIFFE pipeline.

**CI/CD and Workflow Integration:**

* Added a new `spire` job to the GitHub Actions workflow (`.github/workflows/go-build-and-test.yaml`) to automatically start the SPIRE fixture and run SPIFFE E2E tests in CI on Linux runners. This ensures SPIFFE integration is tested on every pull request.

**Developer Tooling and Automation:**

* Introduced new Makefile targets (`spire-up`, `spire-down`, `spire-logs`, `spiffe-tests`) to manage the SPIRE fixture lifecycle and run SPIFFE E2E tests locally. These targets orchestrate starting/stopping the Dockerized SPIRE server/agent and running the tests with correct environment variables.

**SPIRE Fixture Implementation:**

* Added the full SPIRE fixture under `hack/spire/`, including:
  * `docker-compose.yml` for orchestrating SPIRE server and agent containers
  * `server.conf` and `agent.conf` for SPIRE configuration
  * `up.sh` and `down.sh` scripts to automate setup and teardown, including CA generation, join token creation, socket management, and workload registration
  * `.gitignore` for ignoring generated artifacts (socket, bundle, upstream CA) [[1]](diffhunk://#diff-d0e339fcf66235b03140ad8d7f48a01b053b8af941fb41df5f8d0c6f88d91200R1-R46) [[2]](diffhunk://#diff-7a872004bd9ed824ea68bab075c48abd76370261a4d4cb7d3d11faf794b593b3R1-R44) [[3]](diffhunk://#diff-f235e182aa4384879984850a6b00c5d71294a9b216ec3f5d3b6c399efb413494R1-R26) [[4]](diffhunk://#diff-3f1b5bc50021ff1d8bb38c3b35b3b298bffe12abe03be1395eaa36f3ae3d2750R1-R104) [[5]](diffhunk://#diff-90becfa4704ee1f9da961dba41f7ab522837bf6d0e4b811c0c09d42afc9c2e33R1-R24) [[6]](diffhunk://#diff-92ad59745365a393afe30ca832e284dbf7b26d428b1b03f6306d92d355532c45R1-R3)

**End-to-End SPIFFE Test:**

* Added `spiffe/e2e_test.go`, a comprehensive E2E test (build tag `e2e`) that:
  * Connects to the local SPIRE agent via the Workload API socket
  * Signs an in-toto statement using the issued SVID
  * Asserts the certificate chain (leaf + intermediate)
  * Verifies the signature against the exported trust bundle
  * Validates identity and policy matching via the API layer

These changes collectively ensure robust, automated testing of SPIFFE-based signing and verification, and provide a repeatable local workflow for development and debugging.

---

**References:**
- CI/CD and Workflow Integration:
- Developer Tooling and Automation:
- SPIRE Fixture Implementation: [[1]](diffhunk://#diff-d0e339fcf66235b03140ad8d7f48a01b053b8af941fb41df5f8d0c6f88d91200R1-R46) [[2]](diffhunk://#diff-7a872004bd9ed824ea68bab075c48abd76370261a4d4cb7d3d11faf794b593b3R1-R44) [[3]](diffhunk://#diff-f235e182aa4384879984850a6b00c5d71294a9b216ec3f5d3b6c399efb413494R1-R26) [[4]](diffhunk://#diff-3f1b5bc50021ff1d8bb38c3b35b3b298bffe12abe03be1395eaa36f3ae3d2750R1-R104) [[5]](diffhunk://#diff-90becfa4704ee1f9da961dba41f7ab522837bf6d0e4b811c0c09d42afc9c2e33R1-R24) [[6]](diffhunk://#diff-92ad59745365a393afe30ca832e284dbf7b26d428b1b03f6306d92d355532c45R1-R3)
- End-to-End SPIFFE Test: