### PR TITLE
Spiffe timestamp

### DIFF
--- a/bundle/signer.go
+++ b/bundle/signer.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/carabiner-dev/signer/options"
+	"github.com/carabiner-dev/signer/sigstore"
 )
 
 // BundleSigner abstracts the signer implementation to make it easy to mock
@@ -81,12 +82,23 @@ func (bs *DefaultSigner) BuildBundleOptions(opts *options.Signer, cp CredentialP
 	bundleOptions.CertificateProviderOptions = cpOpts
 
 	if opts.Timestamp {
-		if opts.SigningConfig == nil {
-			return nil, fmt.Errorf("signing config not set; required when Timestamp is enabled")
+		signingConfig := opts.SigningConfig
+		if signingConfig == nil {
+			// Backends that don't carry a sigstore SigningConfig (notably
+			// SPIFFE) still need TSA URLs to satisfy the Timestamp toggle.
+			// Fall back to a TSA-only config synthesized from the embedded
+			// sigstore-roots. Fulcio / OIDC / Rekor URL slices are
+			// intentionally left empty so this fallback only contributes
+			// timestamping, never other sigstore endpoints.
+			sc, err := tsaOnlySigningConfig(opts.SigstoreRootsData)
+			if err != nil {
+				return nil, fmt.Errorf("synthesizing TSA-only signing config: %w", err)
+			}
+			signingConfig = sc
 		}
 		tsaURLs, err := root.SelectServices(
-			opts.SigningConfig.TimestampAuthorityURLs(),
-			opts.SigningConfig.TimestampAuthorityURLsConfig(), []uint32{1}, time.Now(),
+			signingConfig.TimestampAuthorityURLs(),
+			signingConfig.TimestampAuthorityURLsConfig(), []uint32{1}, time.Now(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("fetching time stamp authority URLs: %w", err)
@@ -123,6 +135,37 @@ func (bs *DefaultSigner) BuildBundleOptions(opts *options.Signer, cp CredentialP
 	}
 
 	return &bundleOptions, nil
+}
+
+// tsaOnlySigningConfig builds a sigstore SigningConfig containing
+// only the TSA URLs from the first parsed instance in rootsData.
+// Fulcio, OIDC, and Rekor URL slices are intentionally left empty so
+// the TSA-only fallback can't accidentally pull in non-TSA sigstore
+// endpoints (e.g. for a SPIFFE-backed signature). Used by
+// BuildBundleOptions when Timestamp is requested but the caller
+// supplied no sigstore SigningConfig of its own.
+func tsaOnlySigningConfig(rootsData []byte) (*root.SigningConfig, error) {
+	parsed, err := sigstore.ParseRoots(rootsData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing sigstore roots: %w", err)
+	}
+	if len(parsed.Roots) == 0 || parsed.Roots[0].SigningConfig == nil {
+		return nil, errors.New("no signing config in sigstore roots")
+	}
+	src := parsed.Roots[0].SigningConfig
+	tsaURLs := src.TimestampAuthorityURLs()
+	if len(tsaURLs) == 0 {
+		return nil, errors.New("no TSA URLs in sigstore roots")
+	}
+	return root.NewSigningConfig(
+		root.SigningConfigMediaType02,
+		nil, // no Fulcio
+		nil, // no OIDC
+		nil, // no Rekor
+		root.ServiceConfiguration{},
+		tsaURLs,
+		src.TimestampAuthorityURLsConfig(),
+	)
 }
 
 // SignBundle signs the DSSE envelop and returns the new bundle

--- a/bundle/signer_test.go
+++ b/bundle/signer_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/signer/bundle"
+	"github.com/carabiner-dev/signer/bundle/bundlefakes"
+	"github.com/carabiner-dev/signer/options"
+	"github.com/carabiner-dev/signer/sigstore"
+)
+
+// TestBuildBundleOptionsTSAFallback covers the SPIFFE-style path:
+// Timestamp is requested but SigningConfig is nil. BuildBundleOptions
+// must synthesize a TSA-only SigningConfig from the embedded sigstore
+// roots and populate bundleOptions.TimestampAuthorities, without
+// dragging in Fulcio / OIDC / Rekor.
+func TestBuildBundleOptionsTSAFallback(t *testing.T) {
+	t.Parallel()
+
+	cp := &bundlefakes.FakeCredentialProvider{}
+	cp.CertificateProviderReturns(nil, nil)
+
+	bs := &bundle.DefaultSigner{}
+
+	t.Run("tsa-fallback-when-signing-config-nil", func(t *testing.T) {
+		t.Parallel()
+		opts := &options.Signer{
+			SigstoreRootsData: sigstore.DefaultRoots,
+			Sigstore: options.Sigstore{
+				Instance: sigstore.Instance{
+					Timestamp: true,
+				},
+			},
+		}
+		bo, err := bs.BuildBundleOptions(opts, cp)
+		require.NoError(t, err)
+		require.NotNil(t, bo)
+		require.NotEmpty(t, bo.TimestampAuthorities,
+			"BuildBundleOptions must populate TimestampAuthorities from the TSA-only fallback")
+	})
+
+	t.Run("no-timestamp-no-fallback", func(t *testing.T) {
+		t.Parallel()
+		opts := &options.Signer{
+			SigstoreRootsData: sigstore.DefaultRoots,
+			Sigstore:          options.Sigstore{Instance: sigstore.Instance{Timestamp: false}},
+		}
+		bo, err := bs.BuildBundleOptions(opts, cp)
+		require.NoError(t, err)
+		require.NotNil(t, bo)
+		require.Empty(t, bo.TimestampAuthorities,
+			"BuildBundleOptions must not call the TSA fallback when Timestamp is off")
+	})
+
+	t.Run("explicit-signing-config-wins", func(t *testing.T) {
+		t.Parallel()
+		// When the caller supplies their own SigningConfig (sigstore
+		// path), BuildBundleOptions must use it directly and not fall
+		// back to embedded defaults.
+		parsed, err := sigstore.ParseRoots(sigstore.DefaultRoots)
+		require.NoError(t, err)
+		require.NotEmpty(t, parsed.Roots)
+		require.NotNil(t, parsed.Roots[0].SigningConfig)
+
+		opts := &options.Signer{
+			SigstoreRootsData: sigstore.DefaultRoots,
+			Sigstore: options.Sigstore{
+				Instance: sigstore.Instance{
+					Timestamp:     true,
+					SigningConfig: parsed.Roots[0].SigningConfig,
+				},
+			},
+		}
+		bo, err := bs.BuildBundleOptions(opts, cp)
+		require.NoError(t, err)
+		require.NotNil(t, bo)
+		require.NotEmpty(t, bo.TimestampAuthorities)
+	})
+}

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -114,6 +114,7 @@ always-on baseline verifier.
 | --- | --- | --- |
 | `--spiffe-trust-domain` | expected SPIFFE trust domain (e.g. `prod.example.org`) |  |
 | `--spiffe-socket`       | Workload API socket (`unix:///run/spire/sockets/api.sock`) | `SPIFFE_ENDPOINT_SOCKET` |
+| `--spiffe-timestamp`    | attach an RFC 3161 TSA-signed timestamp to the bundle (default `true`); suppressed and replaced by `--signing-timestamp` when bundled via `SignerSet`. See [SPIFFE timestamping](spiffe-timestamping.md) for the full flow. |  |
 
 `BuildSigner()` returns an `*options.Signer` with
 `Backend = BackendSpiffe`. The SPIFFE backend can't lazy-build its
@@ -145,7 +146,8 @@ contribute their flags to help text but are otherwise inert.
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--signing-backend` | signing backend (`key`, `sigstore`, `spiffe`) | auto-detect (see below) |
+| `--signing-backend`   | signing backend (`key`, `sigstore`, `spiffe`) | auto-detect (see below) |
+| `--signing-timestamp` | attach an RFC 3161 TSA-signed timestamp to the bundle (applies to sigstore and SPIFFE; ignored by the key backend). When bundled here, this replaces the per-backend `--sigstore-timestamp` and `--spiffe-timestamp` flags. See [SPIFFE timestamping](spiffe-timestamping.md). | `true` |
 
 **Auto-detection.** When `--signing-backend` is unset, the resolved
 backend is inferred from the populated child *flags*:

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -8,10 +8,23 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 	"sigs.k8s.io/release-utils/version"
+)
+
+// TUF metadata initialization is brittle on transient filesystem
+// contention: on Windows the atomic rename of the freshly-created
+// temp metadata file fails when antivirus / indexer briefly locks it
+// ("Access is denied"), and on slow disks any platform can hit a
+// short window where the rename or initial fetch fails. The
+// failure mode is recoverable on retry, so we bound a few attempts
+// here rather than blow up the verifier on a sub-second I/O blip.
+const (
+	tufInitMaxAttempts  = 3
+	tufInitInitialDelay = 250 * time.Millisecond
 )
 
 // TufOptions captures the TUF options handled by bind
@@ -22,7 +35,11 @@ type TufOptions struct {
 	RootData    []byte `json:"root-data"`
 }
 
-// GetClient returns a TUF client configured with the options
+// GetClient returns a TUF client configured with the options. The
+// underlying tuf.New call is retried with exponential backoff on
+// transient errors (see the tufInit* constants for rationale); the
+// last error is returned after exhausting attempts so legitimate
+// configuration problems still surface.
 func GetClient(opts *TufOptions) (*tuf.Client, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -41,11 +58,22 @@ func GetClient(opts *TufOptions) (*tuf.Client, error) {
 		Fetcher:                   Defaultfetcher(),
 	}
 
-	client, err := tuf.New(tufOpts)
-	if err != nil {
-		return nil, fmt.Errorf("creating TUF client: %w", err)
+	var (
+		client  *tuf.Client
+		lastErr error
+		delay   = tufInitInitialDelay
+	)
+	for attempt := 1; attempt <= tufInitMaxAttempts; attempt++ {
+		client, lastErr = tuf.New(tufOpts)
+		if lastErr == nil {
+			return client, nil
+		}
+		if attempt < tufInitMaxAttempts {
+			time.Sleep(delay)
+			delay *= 2
+		}
 	}
-	return client, nil
+	return nil, fmt.Errorf("creating TUF client (after %d attempts): %w", tufInitMaxAttempts, lastErr)
 }
 
 // GetRoot fetches the trusted root from the configured URL or from

--- a/options/signer_set.go
+++ b/options/signer_set.go
@@ -51,8 +51,9 @@ type SignerSet struct {
 	// ManagedTimestamp on the child) when bundled here. BuildSigner
 	// propagates this value into the dispatched child's
 	// *options.Signer.Timestamp, overriding any per-backend default.
-	// SPIFFE consumes this once TSA-for-SPIFFE wiring lands; key
-	// backend ignores it (DSSE envelopes don't carry timestamps).
+	// Applies to sigstore and SPIFFE (whose BuildSigner attaches a
+	// TSA-only SigningConfig); the key backend ignores it because
+	// DSSE envelopes carry no timestamps.
 	Timestamp bool
 
 	Keys     *KeysSign
@@ -70,16 +71,18 @@ var _ command.OptionsSet = (*SignerSet)(nil)
 // resolveBackend can auto-detect from the populated child flags;
 // users who want a specific backend can override --signing-backend.
 func DefaultSignerSet() *SignerSet {
-	sigstore := DefaultSigstoreSignSet("sigstore")
-	// Suppress the per-backend --sigstore-timestamp flag when bundled;
-	// the single --signing-timestamp at this level is the user-facing
-	// knob.
-	sigstore.Sign.ManagedTimestamp = true
+	sigstoreSet := DefaultSigstoreSignSet("sigstore")
+	spiffeSet := DefaultSpiffeSignSet("spiffe")
+	// Suppress the per-backend --sigstore-timestamp / --spiffe-timestamp
+	// flags when bundled; the single --signing-timestamp at this level
+	// is the user-facing knob.
+	sigstoreSet.Sign.ManagedTimestamp = true
+	spiffeSet.Sign.ManagedTimestamp = true
 	return &SignerSet{
 		Timestamp: true,
 		Keys:      DefaultKeysSign(),
-		Sigstore:  sigstore,
-		Spiffe:    DefaultSpiffeSignSet("spiffe"),
+		Sigstore:  sigstoreSet,
+		Spiffe:    spiffeSet,
 	}
 }
 
@@ -97,7 +100,7 @@ func (s *SignerSet) Config() *command.OptionsSetConfig {
 				},
 				"signing-timestamp": {
 					Long: "signing-timestamp",
-					Help: "attach an RFC 3161 timestamp to the signature (sigstore today; SPIFFE once TSA wiring lands)",
+					Help: "attach an RFC 3161 TSA-signed timestamp to the bundle (applies to sigstore and SPIFFE; ignored by the key backend)",
 				},
 			},
 		}

--- a/options/signer_set.go
+++ b/options/signer_set.go
@@ -100,7 +100,7 @@ func (s *SignerSet) Config() *command.OptionsSetConfig {
 				},
 				"signing-timestamp": {
 					Long: "signing-timestamp",
-					Help: "attach an RFC 3161 TSA-signed timestamp to the bundle (applies to sigstore and SPIFFE; ignored by the key backend)",
+					Help: "Add an RFC 3161 TSA-signed timestamp (sigstore/SPIFFE)",
 				},
 			},
 		}

--- a/options/signer_set.go
+++ b/options/signer_set.go
@@ -44,6 +44,17 @@ type SignerSet struct {
 	// the runtime signer's default.
 	Backend string
 
+	// Timestamp controls whether the resulting bundle carries an RFC
+	// 3161 timestamp. Bound to --signing-timestamp; the flag is the
+	// single user-facing knob across backends so each per-backend
+	// child has its own --<prefix>-timestamp suppressed (via
+	// ManagedTimestamp on the child) when bundled here. BuildSigner
+	// propagates this value into the dispatched child's
+	// *options.Signer.Timestamp, overriding any per-backend default.
+	// SPIFFE consumes this once TSA-for-SPIFFE wiring lands; key
+	// backend ignores it (DSSE envelopes don't carry timestamps).
+	Timestamp bool
+
 	Keys     *KeysSign
 	Sigstore *SigstoreSignSet
 	Spiffe   *SpiffeSignSet
@@ -59,10 +70,16 @@ var _ command.OptionsSet = (*SignerSet)(nil)
 // resolveBackend can auto-detect from the populated child flags;
 // users who want a specific backend can override --signing-backend.
 func DefaultSignerSet() *SignerSet {
+	sigstore := DefaultSigstoreSignSet("sigstore")
+	// Suppress the per-backend --sigstore-timestamp flag when bundled;
+	// the single --signing-timestamp at this level is the user-facing
+	// knob.
+	sigstore.Sign.ManagedTimestamp = true
 	return &SignerSet{
-		Keys:     DefaultKeysSign(),
-		Sigstore: DefaultSigstoreSignSet("sigstore"),
-		Spiffe:   DefaultSpiffeSignSet("spiffe"),
+		Timestamp: true,
+		Keys:      DefaultKeysSign(),
+		Sigstore:  sigstore,
+		Spiffe:    DefaultSpiffeSignSet("spiffe"),
 	}
 }
 
@@ -78,6 +95,10 @@ func (s *SignerSet) Config() *command.OptionsSetConfig {
 					Help: fmt.Sprintf("signing backend (%s | %s | %s) default %s",
 						BackendKey, BackendSigstore, BackendSpiffe, BackendSigstore),
 				},
+				"signing-timestamp": {
+					Long: "signing-timestamp",
+					Help: "attach an RFC 3161 timestamp to the signature (sigstore today; SPIFFE once TSA wiring lands)",
+				},
 			},
 		}
 	}
@@ -89,11 +110,18 @@ func (s *SignerSet) Config() *command.OptionsSetConfig {
 // so --help output is stable across runs.
 func (s *SignerSet) AddFlags(cmd *cobra.Command) {
 	cfg := s.Config()
-	cmd.PersistentFlags().StringVar(
+	pf := cmd.PersistentFlags()
+	pf.StringVar(
 		&s.Backend,
 		cfg.LongFlag("signing-backend"),
 		s.Backend,
 		cfg.HelpText("signing-backend"),
+	)
+	pf.BoolVar(
+		&s.Timestamp,
+		cfg.LongFlag("signing-timestamp"),
+		s.Timestamp,
+		cfg.HelpText("signing-timestamp"),
 	)
 	if s.Keys != nil {
 		s.Keys.AddFlags(cmd)
@@ -183,25 +211,35 @@ func (s *SignerSet) BuildSigner() (*Signer, error) {
 	if err != nil {
 		return nil, err
 	}
+	var target *Signer
 	switch backend {
 	case BackendKey:
 		if s.Keys == nil {
 			return nil, errors.New("SignerSet: --signing-backend=key but Keys is nil")
 		}
-		return s.Keys.BuildSigner()
+		target, err = s.Keys.BuildSigner()
 	case BackendSigstore:
 		if s.Sigstore == nil {
 			return nil, errors.New("SignerSet: --signing-backend=sigstore but Sigstore is nil")
 		}
-		return s.Sigstore.BuildSigner()
+		target, err = s.Sigstore.BuildSigner()
 	case BackendSpiffe:
 		if s.Spiffe == nil {
 			return nil, errors.New("SignerSet: --signing-backend=spiffe but Spiffe is nil")
 		}
-		return s.Spiffe.BuildSigner()
+		target, err = s.Spiffe.BuildSigner()
 	default:
 		return nil, fmt.Errorf("SignerSet: unhandled backend %q", backend)
 	}
+	if err != nil {
+		return nil, err
+	}
+	// The bundled --signing-timestamp wins over per-backend defaults.
+	// For BackendKey this is a no-op (DSSE envelopes carry no
+	// timestamp); for BackendSpiffe it lights up once TSA-for-SPIFFE
+	// wiring lands.
+	target.Timestamp = s.Timestamp
+	return target, nil
 }
 
 // BuildCredentialProvider returns the *spiffe.CredentialProvider

--- a/options/signer_set_test.go
+++ b/options/signer_set_test.go
@@ -19,6 +19,7 @@ func TestSignerSetAddFlags(t *testing.T) {
 
 	for _, name := range []string{
 		"signing-backend",
+		"signing-timestamp",
 		"signing-key",
 		"signing-key-passphrase-env",
 		"sigstore-roots",
@@ -27,6 +28,54 @@ func TestSignerSetAddFlags(t *testing.T) {
 	} {
 		require.NotNil(t, cmd.PersistentFlags().Lookup(name), "flag %q must be registered", name)
 	}
+
+	// --sigstore-timestamp is suppressed when bundled — the bundled
+	// --signing-timestamp is the single user-facing knob.
+	require.Nil(t, cmd.PersistentFlags().Lookup("sigstore-timestamp"),
+		"--sigstore-timestamp must NOT be registered when SigstoreSign.ManagedTimestamp is set by SignerSet")
+}
+
+// TestSignerSetTimestampPropagates asserts the bundled
+// --signing-timestamp value flows into the resolved *options.Signer
+// regardless of backend.
+func TestSignerSetTimestampPropagates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sigstore-true", func(t *testing.T) {
+		t.Parallel()
+		set := DefaultSignerSet()
+		set.Backend = string(BackendSigstore)
+		set.Timestamp = true
+
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.True(t, opts.Timestamp)
+	})
+
+	t.Run("sigstore-false", func(t *testing.T) {
+		t.Parallel()
+		set := DefaultSignerSet()
+		set.Backend = string(BackendSigstore)
+		set.Timestamp = false
+
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.False(t, opts.Timestamp,
+			"SignerSet.Timestamp=false must override the per-instance default")
+	})
+
+	t.Run("key-noop", func(t *testing.T) {
+		t.Parallel()
+		set := DefaultSignerSet()
+		set.Backend = string(BackendKey)
+		set.Timestamp = true
+		set.Keys.PrivateKeyPaths = []string{writeECPrivateKey(t)}
+
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.True(t, opts.Timestamp,
+			"key backend ignores Timestamp at runtime but the field is still set")
+	})
 }
 
 func TestSignerSetValidateUnknownBackend(t *testing.T) {

--- a/options/signer_set_test.go
+++ b/options/signer_set_test.go
@@ -29,10 +29,12 @@ func TestSignerSetAddFlags(t *testing.T) {
 		require.NotNil(t, cmd.PersistentFlags().Lookup(name), "flag %q must be registered", name)
 	}
 
-	// --sigstore-timestamp is suppressed when bundled — the bundled
-	// --signing-timestamp is the single user-facing knob.
-	require.Nil(t, cmd.PersistentFlags().Lookup("sigstore-timestamp"),
-		"--sigstore-timestamp must NOT be registered when SigstoreSign.ManagedTimestamp is set by SignerSet")
+	// Per-backend timestamp flags are suppressed when bundled — the
+	// shared --signing-timestamp is the single user-facing knob.
+	for _, name := range []string{"sigstore-timestamp", "spiffe-timestamp"} {
+		require.Nil(t, cmd.PersistentFlags().Lookup(name),
+			"--%s must NOT be registered when bundled (ManagedTimestamp set by SignerSet)", name)
+	}
 }
 
 // TestSignerSetTimestampPropagates asserts the bundled
@@ -75,6 +77,35 @@ func TestSignerSetTimestampPropagates(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, opts.Timestamp,
 			"key backend ignores Timestamp at runtime but the field is still set")
+	})
+
+	t.Run("spiffe-true-propagates", func(t *testing.T) {
+		t.Parallel()
+		set := DefaultSignerSet()
+		set.Backend = string(BackendSpiffe)
+		set.Timestamp = true
+		// Set socket via field to avoid t.Setenv (incompatible with the
+		// parent t.Parallel chain).
+		set.Spiffe.Sign.SocketPath = testSpiffeSocket
+
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.True(t, opts.Timestamp)
+		require.Nil(t, opts.SigningConfig,
+			"options layer should not carry SigningConfig; bundle layer fills it in lazily")
+	})
+
+	t.Run("spiffe-false-overrides-per-set-default", func(t *testing.T) {
+		t.Parallel()
+		set := DefaultSignerSet()
+		set.Backend = string(BackendSpiffe)
+		set.Timestamp = false
+		set.Spiffe.Sign.SocketPath = testSpiffeSocket
+
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.False(t, opts.Timestamp,
+			"SignerSet.Timestamp=false must override SPIFFE per-set default")
 	})
 }
 

--- a/options/sigstore_set.go
+++ b/options/sigstore_set.go
@@ -164,6 +164,13 @@ type SigstoreSign struct {
 	// HideOIDCOptions marks the --oidc-* flags as hidden on the CLI.
 	HideOIDCOptions bool
 
+	// ManagedTimestamp, when true, suppresses registration of the
+	// --<prefix>-timestamp flag in AddFlags. Set by SignerSet so the
+	// bundled --signing-timestamp can be the single user-facing knob;
+	// standalone callers leave this false (default) and get
+	// --sigstore-timestamp under the standard prefix.
+	ManagedTimestamp bool
+
 	config *command.OptionsSetConfig
 }
 
@@ -224,7 +231,9 @@ func (s *SigstoreSign) AddFlags(cmd *cobra.Command) {
 	pf.StringVar(&s.OIDCClientSecret, cfg.LongFlag("oidc-client-secret"), s.OIDCClientSecret, cfg.HelpText("oidc-client-secret"))
 	pf.StringVar(&s.OIDCTokenFile, cfg.LongFlag("oidc-token-file"), s.OIDCTokenFile, cfg.HelpText("oidc-token-file"))
 	pf.BoolVar(&s.RekorAppend, cfg.LongFlag("rekor-append"), s.RekorAppend, cfg.HelpText("rekor-append"))
-	pf.BoolVar(&s.Timestamp, cfg.LongFlag("timestamp"), s.Timestamp, cfg.HelpText("timestamp"))
+	if !s.ManagedTimestamp {
+		pf.BoolVar(&s.Timestamp, cfg.LongFlag("timestamp"), s.Timestamp, cfg.HelpText("timestamp"))
+	}
 	pf.BoolVar(&s.DisableSTS, cfg.LongFlag("disable-sts"), s.DisableSTS, cfg.HelpText("disable-sts"))
 
 	if s.HideOIDCOptions {

--- a/options/spiffe_set.go
+++ b/options/spiffe_set.go
@@ -96,7 +96,8 @@ func (c *SpiffeCommon) ParseTrustDomain() (spiffeid.TrustDomain, error) {
 
 // SpiffeSign is the OptionsSet for the signing side of a SPIFFE
 // workflow. It carries the Workload API socket path (with env
-// fallback) used to fetch the X.509-SVID.
+// fallback) used to fetch the X.509-SVID, plus the Timestamp toggle
+// for RFC 3161 TSA stamps.
 type SpiffeSign struct {
 	*SpiffeCommon
 
@@ -106,18 +107,35 @@ type SpiffeSign struct {
 	// Validate fails.
 	SocketPath string
 
+	// Timestamp, when true, attaches an RFC 3161 TSA-signed timestamp
+	// to the bundle. The TSA URL is sourced from the embedded
+	// sigstore-roots.json (the bundle that comes out carries only the
+	// resulting RFC 3161 token, not the rest of the sigstore config).
+	// Bound to --<prefix>-timestamp when ManagedTimestamp is false.
+	Timestamp bool
+
+	// ManagedTimestamp, when true, suppresses registration of the
+	// --<prefix>-timestamp flag. Set by SignerSet so the bundled
+	// --signing-timestamp can be the single user-facing knob;
+	// standalone callers leave this false (default).
+	ManagedTimestamp bool
+
 	config *command.OptionsSetConfig
 }
 
 var _ command.OptionsSet = (*SpiffeSign)(nil)
 
 // DefaultSpiffeSign builds a SpiffeSign sharing the supplied common.
-// Pass nil to allocate a fresh one.
+// Pass nil to allocate a fresh one. Timestamp defaults to true so
+// SVID-signed bundles are durable past SVID expiry by default.
 func DefaultSpiffeSign(common *SpiffeCommon) *SpiffeSign {
 	if common == nil {
 		common = DefaultSpiffeCommon()
 	}
-	return &SpiffeSign{SpiffeCommon: common}
+	return &SpiffeSign{
+		SpiffeCommon: common,
+		Timestamp:    true,
+	}
 }
 
 // Config returns the flag configuration for SpiffeSign.
@@ -129,6 +147,10 @@ func (s *SpiffeSign) Config() *command.OptionsSetConfig {
 					Long: "socket",
 					Help: "SPIFFE Workload API socket path (env fallback: " + spiffeSocketEnv + ")",
 				},
+				"timestamp": {
+					Long: "timestamp",
+					Help: "attach an RFC 3161 TSA-signed timestamp to the bundle (sourced from sigstore.dev TSA)",
+				},
 			},
 		}
 	}
@@ -137,15 +159,25 @@ func (s *SpiffeSign) Config() *command.OptionsSetConfig {
 
 // AddFlags registers SpiffeSign flags. Assumes the caller registers
 // SpiffeCommon's flags separately so --<prefix>-trust-domain is not
-// registered twice.
+// registered twice. The --<prefix>-timestamp flag is suppressed when
+// ManagedTimestamp is true (set by the bundled SignerSet).
 func (s *SpiffeSign) AddFlags(cmd *cobra.Command) {
 	cfg := s.Config()
-	cmd.PersistentFlags().StringVar(
+	pf := cmd.PersistentFlags()
+	pf.StringVar(
 		&s.SocketPath,
 		cfg.LongFlag("socket"),
 		s.SocketPath,
 		cfg.HelpText("socket"),
 	)
+	if !s.ManagedTimestamp {
+		pf.BoolVar(
+			&s.Timestamp,
+			cfg.LongFlag("timestamp"),
+			s.Timestamp,
+			cfg.HelpText("timestamp"),
+		)
+	}
 }
 
 // EffectiveSocketPath returns the explicit SocketPath when set, or
@@ -376,17 +408,21 @@ func (s *SpiffeSignSet) BuildCredentialProvider() (*spiffe.CredentialProvider, e
 }
 
 // BuildSigner returns a *Signer wired for the SPIFFE backend: Backend
-// set to BackendSpiffe. Callers must additionally call
-// BuildCredentialProvider and assign the result to
-// signer.Signer.Credentials before signing — the SPIFFE backend
-// cannot construct credentials from Options alone. Validates the set
-// before returning.
+// set to BackendSpiffe and Timestamp propagated from Sign.Timestamp.
+// Callers must additionally call BuildCredentialProvider and assign
+// the result to signer.Signer.Credentials before signing — the
+// SPIFFE backend cannot construct credentials from Options alone.
+// Validates the set before returning.
 //
-// The returned Signer carries no sigstore-derived state: SPIFFE
-// bundles are signed entirely from the SVID, so SigningConfig stays
-// nil and Timestamp / AppendToRekor stay at their zero (false)
-// defaults. Anything else would leak sigstore configuration into the
-// SPIFFE bundle.
+// SigningConfig is left nil; the bundle layer
+// (bundle.DefaultSigner.BuildBundleOptions) synthesizes a TSA-only
+// SigningConfig at sign time when Timestamp is true, sourcing the
+// TSA URLs from the embedded sigstore-roots. Keeping that synthesis
+// out of the OptionsSet layer keeps SpiffeSignSet purely about
+// flag-binding.
+//
+// AppendToRekor is left zero — SPIFFE-signed bundles never go to
+// Rekor.
 func (s *SpiffeSignSet) BuildSigner() (*Signer, error) {
 	if s == nil || s.Sign == nil {
 		return nil, errors.New("SpiffeSignSet: nil; construct via DefaultSpiffeSignSet")
@@ -396,6 +432,7 @@ func (s *SpiffeSignSet) BuildSigner() (*Signer, error) {
 	}
 	target := DefaultSigner
 	target.Backend = BackendSpiffe
+	target.Timestamp = s.Sign.Timestamp
 	return &target, nil
 }
 

--- a/options/spiffe_set_test.go
+++ b/options/spiffe_set_test.go
@@ -71,6 +71,7 @@ func TestSpiffeSignAddFlags(t *testing.T) {
 		cmd := &cobra.Command{Use: "test"}
 		s.AddFlags(cmd)
 		require.NotNil(t, cmd.PersistentFlags().Lookup("socket"))
+		require.NotNil(t, cmd.PersistentFlags().Lookup("timestamp"))
 	})
 
 	t.Run("flag-prefix-applies", func(t *testing.T) {
@@ -80,6 +81,52 @@ func TestSpiffeSignAddFlags(t *testing.T) {
 		cmd := &cobra.Command{Use: "test"}
 		s.AddFlags(cmd)
 		require.NotNil(t, cmd.PersistentFlags().Lookup("spiffe-socket"))
+		require.NotNil(t, cmd.PersistentFlags().Lookup("spiffe-timestamp"))
+	})
+
+	t.Run("managed-timestamp-suppresses-flag", func(t *testing.T) {
+		t.Parallel()
+		s := DefaultSpiffeSign(nil)
+		s.Config().FlagPrefix = "spiffe"
+		s.ManagedTimestamp = true
+		cmd := &cobra.Command{Use: "test"}
+		s.AddFlags(cmd)
+		require.NotNil(t, cmd.PersistentFlags().Lookup("spiffe-socket"),
+			"socket flag must still register when timestamp is managed externally")
+		require.Nil(t, cmd.PersistentFlags().Lookup("spiffe-timestamp"),
+			"--spiffe-timestamp must be suppressed when ManagedTimestamp=true")
+	})
+
+	t.Run("default-timestamp-is-true", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, DefaultSpiffeSign(nil).Timestamp,
+			"SPIFFE bundles default to TSA-stamped so they outlive SVID expiry")
+	})
+}
+
+// TestSpiffeSignSetBuildSignerTimestamp confirms BuildSigner only
+// propagates Timestamp into the resulting *options.Signer; SigningConfig
+// stays nil. The TSA-only SigningConfig is synthesized at sign time
+// by bundle.DefaultSigner.BuildBundleOptions, not by the OptionsSet.
+func TestSpiffeSignSetBuildSignerTimestamp(t *testing.T) {
+	t.Setenv("SPIFFE_ENDPOINT_SOCKET", testSpiffeSocket)
+
+	t.Run("default-true-no-signing-config", func(t *testing.T) {
+		set := DefaultSpiffeSignSet("spiffe")
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.True(t, opts.Timestamp)
+		require.Nil(t, opts.SigningConfig,
+			"options layer must not carry sigstore SigningConfig; bundle layer synthesizes it")
+	})
+
+	t.Run("explicit-false", func(t *testing.T) {
+		set := DefaultSpiffeSignSet("spiffe")
+		set.Sign.Timestamp = false
+		opts, err := set.BuildSigner()
+		require.NoError(t, err)
+		require.False(t, opts.Timestamp)
+		require.Nil(t, opts.SigningConfig)
 	})
 }
 

--- a/spiffe/e2e_test.go
+++ b/spiffe/e2e_test.go
@@ -132,3 +132,69 @@ func TestE2ESPIFFESignAndVerify(t *testing.T) {
 		},
 	}), "regex path match should succeed")
 }
+
+// TestE2ESPIFFESignAndVerifyWithTimestamp exercises the TSA-stamped
+// SPIFFE pipeline: sign with --signing-timestamp on, then verify
+// against the SPIRE upstream root *and* sigstore's TSA. Verifies both
+// that the bundle carries an RFC 3161 TimeStampToken and that the
+// SPIFFE verifier reports verified timestamps in the result.
+//
+// Requires `make spire-up` AND outbound network reachability to
+// timestamp.sigstore.dev. Skipped without env vars; the t.Logf branch
+// records when network failure means we couldn't validate the path.
+func TestE2ESPIFFESignAndVerifyWithTimestamp(t *testing.T) {
+	socketAddr := os.Getenv("SPIFFE_ENDPOINT_SOCKET")
+	bundlePath := os.Getenv("SPIFFE_TRUST_BUNDLE")
+	if socketAddr == "" || bundlePath == "" {
+		t.Skip("SPIFFE_ENDPOINT_SOCKET / SPIFFE_TRUST_BUNDLE unset — run `make spire-up` first")
+	}
+
+	// Build the signer through the bundled SignerSet path with TSA on
+	// (default for SPIFFE in DefaultSignerSet).
+	set := options.DefaultSignerSet()
+	set.Backend = string(options.BackendSpiffe)
+	set.Spiffe.Sign.SocketPath = socketAddr
+	require.True(t, set.Timestamp, "DefaultSignerSet should default Timestamp=true")
+
+	s, err := signerlib.NewSignerFromSet(set)
+	require.NoError(t, err, "building signer from set")
+	t.Cleanup(func() {
+		if cerr := s.Close(); cerr != nil {
+			t.Logf("closing signer: %v", cerr)
+		}
+	})
+
+	statement := []byte(`{` +
+		`"_type":"https://in-toto.io/Statement/v1",` +
+		`"subject":[{"name":"e2e-tsa","digest":{"sha256":"0000000000000000000000000000000000000000000000000000000000000000"}}],` +
+		`"predicateType":"https://example.com/p/v1",` +
+		`"predicate":{}` +
+		`}`)
+	bndl, err := s.SignStatementBundle(statement)
+	if err != nil {
+		// TSA POST may have failed (network / sigstore.dev availability).
+		// Skip rather than fail to keep the test useful in offline CI.
+		t.Skipf("signing with TSA failed (may be a network issue): %v", err)
+	}
+
+	// Bundle should carry the RFC 3161 TimeStampToken.
+	require.NotNil(t, bndl.GetVerificationMaterial())
+	require.NotNil(t, bndl.GetVerificationMaterial().GetTimestampVerificationData(),
+		"TSA-stamped bundle must carry timestamp verification data")
+	require.NotEmpty(t, bndl.GetVerificationMaterial().GetTimestampVerificationData().GetRfc3161Timestamps(),
+		"TSA-stamped bundle must carry at least one RFC 3161 token")
+
+	// Verify — the SPIFFE verifier should validate the TSA token
+	// against the embedded sigstore TSA root, populate
+	// VerifiedTimestamps, and use the verified time for SVID chain
+	// validation (proven indirectly: verification succeeds).
+	verifier := signerlib.NewVerifier(func(v *options.Verifier) {
+		v.TrustRootsPath = bundlePath
+	})
+	result, err := verifier.VerifyParsedBundle(bndl)
+	require.NoError(t, err, "verifying TSA-stamped bundle")
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.VerifiedTimestamps,
+		"SPIFFE verifier must report at least one verified TSA timestamp")
+	require.Equal(t, "TimestampAuthority", result.VerifiedTimestamps[0].Type)
+}

--- a/spiffe/verifier/verifier.go
+++ b/spiffe/verifier/verifier.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sync"
 	"time"
 
 	intoto "github.com/in-toto/attestation/go/v1"
@@ -52,20 +53,34 @@ type VerifierOptions struct {
 	// Mutually exclusive with ExpectedPath.
 	ExpectedPathRegex *regexp.Regexp
 
-	// TSATrustedMaterial, when non-nil, is used to validate any RFC 3161
-	// timestamps embedded in the bundle. The earliest verified timestamp
-	// time then drives SVID chain validation (CurrentTime in
-	// x509.VerifyOptions), letting bundles outlive the SVID's TTL.
-	// When the bundle has timestamps but TSATrustedMaterial is nil, or
-	// the validation produces no verified timestamps, chain validation
-	// falls back to time.Now() — current behavior.
-	TSATrustedMaterial root.TrustedMaterial
+	// TSAMaterialLoader, when non-nil, returns a TrustedMaterial used
+	// to validate any RFC 3161 timestamps embedded in the bundle.
+	// Called lazily on the first bundle that actually carries
+	// timestamps; the returned material is cached on the Verifier so
+	// subsequent verifications skip the (potentially network-bound)
+	// fetch. Typically wraps tuf.GetRoot + NewTrustedRootFromJSON
+	// against the embedded sigstore-roots; the SPIFFE verifier itself
+	// stays free of TUF / sigstore-package coupling.
+	//
+	// When this is nil and the bundle carries timestamps, chain
+	// validation falls back to time.Now(). When it's set but the
+	// loader returns an error, verification fails closed — silently
+	// degrading would be a bypass.
+	TSAMaterialLoader func() (root.TrustedMaterial, error)
 }
 
 // Verifier validates SPIFFE-signed bundles against a pinned SPIRE trust root
 // and enforces SPIFFE identity matchers on the SVID leaf.
 type Verifier struct {
 	opts VerifierOptions
+
+	// tsaCache holds the materialized TrustedMaterial returned by
+	// opts.TSAMaterialLoader. tsaOnce makes the load happen at most
+	// once per Verifier; tsaCacheErr stores a load failure so it
+	// surfaces consistently across calls.
+	tsaCache    root.TrustedMaterial
+	tsaCacheErr error
+	tsaOnce     sync.Once
 }
 
 // NewVerifier creates a SPIFFE Verifier. Returns an error if the trust roots
@@ -80,15 +95,30 @@ func NewVerifier(opts VerifierOptions) (*Verifier, error) {
 	return &Verifier{opts: opts}, nil
 }
 
-// SetTSATrustedMaterial wires a TrustedMaterial used to validate any
-// RFC 3161 timestamps in incoming bundles. Typically called by the
-// outer signer.NewVerifier after constructing the SPIFFE verifier
-// from SPIFFE-side options, since the trust material lives in the
-// sigstore-roots configuration which the SPIFFE options don't carry.
-// Nil clears the wiring and reverts the verifier to time.Now()-based
+// SetTSAMaterialLoader wires a lazy loader that returns the
+// TrustedMaterial used to validate any RFC 3161 timestamps in
+// incoming bundles. Typically called by the outer signer.NewVerifier
+// after constructing the SPIFFE verifier, since the trust material
+// lives in the sigstore-roots configuration which the SPIFFE options
+// don't carry. The loader is invoked at most once per Verifier and
+// only when a bundle that needs TSA validation is presented; nil
+// clears the wiring and reverts the verifier to time.Now()-based
 // chain validation.
-func (v *Verifier) SetTSATrustedMaterial(tm root.TrustedMaterial) {
-	v.opts.TSATrustedMaterial = tm
+func (v *Verifier) SetTSAMaterialLoader(loader func() (root.TrustedMaterial, error)) {
+	v.opts.TSAMaterialLoader = loader
+}
+
+// resolveTSAMaterial calls TSAMaterialLoader at most once, caches the
+// result, and returns it on subsequent calls. Returns (nil, nil) when
+// no loader is configured.
+func (v *Verifier) resolveTSAMaterial() (root.TrustedMaterial, error) {
+	if v.opts.TSAMaterialLoader == nil {
+		return nil, nil
+	}
+	v.tsaOnce.Do(func() {
+		v.tsaCache, v.tsaCacheErr = v.opts.TSAMaterialLoader()
+	})
+	return v.tsaCache, v.tsaCacheErr
 }
 
 // NewVerifierFromOptions builds a Verifier from the verification options
@@ -176,7 +206,7 @@ func (v *Verifier) Verify(opts *options.Verification, bndl *sbundle.Bundle) (*ve
 		intermediates.AddCert(c)
 	}
 
-	chainTime, verifiedTimestamps, err := chainValidationTime(bndl, effective.TSATrustedMaterial)
+	chainTime, verifiedTimestamps, err := v.chainValidationTime(bndl)
 	if err != nil {
 		return nil, err
 	}
@@ -261,14 +291,18 @@ func (v *Verifier) effectiveOptions(opts *options.Verification) (VerifierOptions
 
 // chainValidationTime returns the time to use for SVID chain
 // validation along with any RFC 3161 timestamps that verified against
-// tm. If the bundle carries timestamps and tm is non-nil, the
-// timestamps are validated against tm and the earliest verified time
-// is returned. Bundle without timestamps, or with timestamps but no
-// tm, returns the zero time so x509.Verify falls back to time.Now().
-// When the bundle has timestamps but every timestamp fails validation
-// against tm, an error is returned — silently falling back would be
-// a security bypass.
-func chainValidationTime(bndl *sbundle.Bundle, tm root.TrustedMaterial) (time.Time, []*root.Timestamp, error) {
+// the lazily-resolved TSA material. The loader is only invoked when
+// the bundle actually carries timestamps, so a verifier wired with a
+// network-bound loader doesn't pay the cost on bundles that don't
+// need TSA validation.
+//
+// Bundle without timestamps → zero time, x509.Verify falls back to
+// time.Now() (legacy behavior). Bundle with timestamps but no loader
+// configured → also zero time (best-effort fallback). Bundle with
+// timestamps + loader fails → error. Bundle with timestamps + loader
+// succeeds + every timestamp fails to validate → error (fail closed
+// to avoid silent bypass).
+func (v *Verifier) chainValidationTime(bndl *sbundle.Bundle) (time.Time, []*root.Timestamp, error) {
 	signedTimestamps, err := bndl.Timestamps()
 	if err != nil {
 		return time.Time{}, nil, fmt.Errorf("reading bundle timestamps: %w", err)
@@ -276,9 +310,11 @@ func chainValidationTime(bndl *sbundle.Bundle, tm root.TrustedMaterial) (time.Ti
 	if len(signedTimestamps) == 0 {
 		return time.Time{}, nil, nil
 	}
+	tm, err := v.resolveTSAMaterial()
+	if err != nil {
+		return time.Time{}, nil, fmt.Errorf("loading TSA trust material: %w", err)
+	}
 	if tm == nil {
-		// Bundle is timestamped but verifier has no TSA roots wired in.
-		// Fall through to time.Now() — current behavior.
 		return time.Time{}, nil, nil
 	}
 	verified, _, err := verify.VerifySignedTimestamp(bndl, tm)

--- a/spiffe/verifier/verifier.go
+++ b/spiffe/verifier/verifier.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	intoto "github.com/in-toto/attestation/go/v1"
 	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -49,6 +51,15 @@ type VerifierOptions struct {
 	// ExpectedPathRegex, when non-nil, must match the SVID's SPIFFE path.
 	// Mutually exclusive with ExpectedPath.
 	ExpectedPathRegex *regexp.Regexp
+
+	// TSATrustedMaterial, when non-nil, is used to validate any RFC 3161
+	// timestamps embedded in the bundle. The earliest verified timestamp
+	// time then drives SVID chain validation (CurrentTime in
+	// x509.VerifyOptions), letting bundles outlive the SVID's TTL.
+	// When the bundle has timestamps but TSATrustedMaterial is nil, or
+	// the validation produces no verified timestamps, chain validation
+	// falls back to time.Now() — current behavior.
+	TSATrustedMaterial root.TrustedMaterial
 }
 
 // Verifier validates SPIFFE-signed bundles against a pinned SPIRE trust root
@@ -67,6 +78,17 @@ func NewVerifier(opts VerifierOptions) (*Verifier, error) {
 		return nil, errors.New("spiffe verifier: ExpectedPath and ExpectedPathRegex are mutually exclusive")
 	}
 	return &Verifier{opts: opts}, nil
+}
+
+// SetTSATrustedMaterial wires a TrustedMaterial used to validate any
+// RFC 3161 timestamps in incoming bundles. Typically called by the
+// outer signer.NewVerifier after constructing the SPIFFE verifier
+// from SPIFFE-side options, since the trust material lives in the
+// sigstore-roots configuration which the SPIFFE options don't carry.
+// Nil clears the wiring and reverts the verifier to time.Now()-based
+// chain validation.
+func (v *Verifier) SetTSATrustedMaterial(tm root.TrustedMaterial) {
+	v.opts.TSATrustedMaterial = tm
 }
 
 // NewVerifierFromOptions builds a Verifier from the verification options
@@ -131,6 +153,12 @@ func loadTrustRoots(opts *options.SpiffeVerification) (*x509.CertPool, error) {
 // *verify.VerificationResult on success (sigstore-specific fields like
 // transparency-log entries are left zero; SPIFFE signatures don't produce
 // them).
+//
+// If the bundle carries RFC 3161 timestamps and TSATrustedMaterial is
+// configured on the verifier, the earliest verified timestamp's time is
+// used as x509.VerifyOptions.CurrentTime so SVID-signed bundles remain
+// verifiable past the SVID's TTL. With timestamps but no
+// TSATrustedMaterial, chain validation falls back to time.Now().
 func (v *Verifier) Verify(opts *options.Verification, bndl *sbundle.Bundle) (*verify.VerificationResult, error) {
 	effective, err := v.effectiveOptions(opts)
 	if err != nil {
@@ -148,11 +176,17 @@ func (v *Verifier) Verify(opts *options.Verification, bndl *sbundle.Bundle) (*ve
 		intermediates.AddCert(c)
 	}
 
+	chainTime, verifiedTimestamps, err := chainValidationTime(bndl, effective.TSATrustedMaterial)
+	if err != nil {
+		return nil, err
+	}
+
 	if _, err := leaf.Verify(x509.VerifyOptions{
 		Roots:         effective.TrustRoots,
 		Intermediates: intermediates,
 		// Accept any EKU — SPIRE SVIDs typically don't set a code-signing EKU.
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		CurrentTime: chainTime, // zero falls back to time.Now() inside x509.Verify
 	}); err != nil {
 		return nil, fmt.Errorf("chain verification failed: %w", err)
 	}
@@ -169,7 +203,16 @@ func (v *Verifier) Verify(opts *options.Verification, bndl *sbundle.Bundle) (*ve
 		return nil, fmt.Errorf("verifying dsse signature: %w", err)
 	}
 
-	return buildResult(bndl, leaf, id), nil
+	result := buildResult(bndl, leaf, id)
+	for _, ts := range verifiedTimestamps {
+		result.VerifiedTimestamps = append(result.VerifiedTimestamps,
+			verify.TimestampVerificationResult{
+				Type:      "TimestampAuthority",
+				URI:       ts.URI,
+				Timestamp: ts.Time,
+			})
+	}
+	return result, nil
 }
 
 // effectiveOptions overlays per-call *options.Verification on top of the
@@ -214,6 +257,44 @@ func (v *Verifier) effectiveOptions(opts *options.Verification) (VerifierOptions
 		eff.ExpectedPath = ""
 	}
 	return eff, nil
+}
+
+// chainValidationTime returns the time to use for SVID chain
+// validation along with any RFC 3161 timestamps that verified against
+// tm. If the bundle carries timestamps and tm is non-nil, the
+// timestamps are validated against tm and the earliest verified time
+// is returned. Bundle without timestamps, or with timestamps but no
+// tm, returns the zero time so x509.Verify falls back to time.Now().
+// When the bundle has timestamps but every timestamp fails validation
+// against tm, an error is returned — silently falling back would be
+// a security bypass.
+func chainValidationTime(bndl *sbundle.Bundle, tm root.TrustedMaterial) (time.Time, []*root.Timestamp, error) {
+	signedTimestamps, err := bndl.Timestamps()
+	if err != nil {
+		return time.Time{}, nil, fmt.Errorf("reading bundle timestamps: %w", err)
+	}
+	if len(signedTimestamps) == 0 {
+		return time.Time{}, nil, nil
+	}
+	if tm == nil {
+		// Bundle is timestamped but verifier has no TSA roots wired in.
+		// Fall through to time.Now() — current behavior.
+		return time.Time{}, nil, nil
+	}
+	verified, _, err := verify.VerifySignedTimestamp(bndl, tm)
+	if err != nil {
+		return time.Time{}, nil, fmt.Errorf("validating bundle timestamps: %w", err)
+	}
+	if len(verified) == 0 {
+		return time.Time{}, nil, errors.New("bundle has timestamps but none verified against the TSA trust material")
+	}
+	earliest := verified[0].Time
+	for _, ts := range verified[1:] {
+		if ts.Time.Before(earliest) {
+			earliest = ts.Time
+		}
+	}
+	return earliest, verified, nil
 }
 
 func matchIdentity(opts VerifierOptions, id spiffeid.ID) error {

--- a/verifier.go
+++ b/verifier.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/carabiner-dev/signer/bundle"
 	"github.com/carabiner-dev/signer/dsse"
+	"github.com/carabiner-dev/signer/internal/tuf"
 	"github.com/carabiner-dev/signer/key"
 	"github.com/carabiner-dev/signer/options"
 	"github.com/carabiner-dev/signer/sigstore"
@@ -65,16 +66,14 @@ func NewVerifier(fnOpts ...options.VerifierOptFunc) *Verifier {
 			// bundle.New contract for the sigstore-roots option.
 			logrus.Errorf("building spiffe verifier: %v", err)
 		} else {
-			// Wire TSA trust material from the embedded sigstore roots so
-			// SVID-signed bundles carrying an RFC 3161 timestamp can be
-			// validated past the SVID's TTL. Best-effort — if the roots
-			// don't carry a usable trusted root we log and let the SPIFFE
-			// verifier fall back to time.Now() chain validation.
-			if tm, terr := tsaTrustedMaterial(rootsData); terr != nil {
-				logrus.Errorf("building TSA trust material for spiffe verifier: %v", terr)
-			} else {
-				sv.SetTSATrustedMaterial(tm)
-			}
+			// Wire a lazy TSA-material loader so SVID-signed bundles
+			// carrying an RFC 3161 timestamp can be validated past the
+			// SVID's TTL. The loader is only invoked when a bundle
+			// actually has timestamps — verifying SPIFFE bundles without
+			// stamps stays purely local. The loader fetches the trusted
+			// root via TUF (cached after first call), matching how the
+			// sigstore verify path resolves it.
+			sv.SetTSAMaterialLoader(tsaMaterialLoader(rootsData))
 			bundleOpts = append(bundleOpts, bundle.WithSpiffeVerifier(sv))
 		}
 	}
@@ -165,22 +164,34 @@ func (v *Verifier) VerifyParsedDSSE(env *sdsse.Envelope, keys []key.PublicKeyPro
 	return v.dsseVerifier.RunVerification(&v.Options, keyVerifier, env, keys)
 }
 
-// tsaTrustedMaterial parses the embedded sigstore-roots data and
-// returns a TrustedMaterial backed by the first instance's trusted
-// root JSON. Used by the SPIFFE verifier to validate RFC 3161
-// timestamps anchored to sigstore's TSA without requiring a TUF fetch
-// at verify time.
-func tsaTrustedMaterial(rootsData []byte) (root.TrustedMaterial, error) {
-	parsed, err := sigstore.ParseRoots(rootsData)
-	if err != nil {
-		return nil, fmt.Errorf("parsing sigstore roots: %w", err)
+// tsaMaterialLoader returns a closure the SPIFFE verifier can call
+// lazily to obtain the TrustedMaterial used for RFC 3161 timestamp
+// validation. The closure parses the supplied sigstore-roots, fetches
+// the trusted root via TUF (cached locally by sigstore-go after the
+// first call), and constructs the TrustedRoot from the proto-JSON the
+// TUF refresh returns. Mirrors the same pattern bundle/verifier.go
+// uses for the sigstore path so behavior and caching are consistent.
+//
+// The closure is invoked at most once per Verifier and only when a
+// bundle that actually carries timestamps is presented, so verifiers
+// that never see TSA-stamped bundles never pay the TUF fetch cost.
+func tsaMaterialLoader(rootsData []byte) func() (root.TrustedMaterial, error) {
+	return func() (root.TrustedMaterial, error) {
+		parsed, err := sigstore.ParseRoots(rootsData)
+		if err != nil {
+			return nil, fmt.Errorf("parsing sigstore roots: %w", err)
+		}
+		if len(parsed.Roots) == 0 {
+			return nil, errors.New("no sigstore instances in roots configuration")
+		}
+		data, err := tuf.GetRoot(&parsed.Roots[0].TufOptions)
+		if err != nil {
+			return nil, fmt.Errorf("fetching trusted root via TUF: %w", err)
+		}
+		tr, err := root.NewTrustedRootFromJSON(data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing trusted root JSON: %w", err)
+		}
+		return tr, nil
 	}
-	if len(parsed.Roots) == 0 || len(parsed.Roots[0].RootData) == 0 {
-		return nil, errors.New("no trusted root data in sigstore roots")
-	}
-	tr, err := root.NewTrustedRootFromJSON(parsed.Roots[0].RootData)
-	if err != nil {
-		return nil, fmt.Errorf("parsing trusted root JSON: %w", err)
-	}
-	return tr, nil
 }

--- a/verifier.go
+++ b/verifier.go
@@ -10,6 +10,7 @@ import (
 
 	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/sirupsen/logrus"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/carabiner-dev/signer/dsse"
 	"github.com/carabiner-dev/signer/key"
 	"github.com/carabiner-dev/signer/options"
+	"github.com/carabiner-dev/signer/sigstore"
 	spiffeverifier "github.com/carabiner-dev/signer/spiffe/verifier"
 )
 
@@ -63,6 +65,16 @@ func NewVerifier(fnOpts ...options.VerifierOptFunc) *Verifier {
 			// bundle.New contract for the sigstore-roots option.
 			logrus.Errorf("building spiffe verifier: %v", err)
 		} else {
+			// Wire TSA trust material from the embedded sigstore roots so
+			// SVID-signed bundles carrying an RFC 3161 timestamp can be
+			// validated past the SVID's TTL. Best-effort — if the roots
+			// don't carry a usable trusted root we log and let the SPIFFE
+			// verifier fall back to time.Now() chain validation.
+			if tm, terr := tsaTrustedMaterial(rootsData); terr != nil {
+				logrus.Errorf("building TSA trust material for spiffe verifier: %v", terr)
+			} else {
+				sv.SetTSATrustedMaterial(tm)
+			}
 			bundleOpts = append(bundleOpts, bundle.WithSpiffeVerifier(sv))
 		}
 	}
@@ -151,4 +163,24 @@ func (v *Verifier) VerifyParsedDSSE(env *sdsse.Envelope, keys []key.PublicKeyPro
 
 	// Verify and return the results
 	return v.dsseVerifier.RunVerification(&v.Options, keyVerifier, env, keys)
+}
+
+// tsaTrustedMaterial parses the embedded sigstore-roots data and
+// returns a TrustedMaterial backed by the first instance's trusted
+// root JSON. Used by the SPIFFE verifier to validate RFC 3161
+// timestamps anchored to sigstore's TSA without requiring a TUF fetch
+// at verify time.
+func tsaTrustedMaterial(rootsData []byte) (root.TrustedMaterial, error) {
+	parsed, err := sigstore.ParseRoots(rootsData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing sigstore roots: %w", err)
+	}
+	if len(parsed.Roots) == 0 || len(parsed.Roots[0].RootData) == 0 {
+		return nil, errors.New("no trusted root data in sigstore roots")
+	}
+	tr, err := root.NewTrustedRootFromJSON(parsed.Roots[0].RootData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing trusted root JSON: %w", err)
+	}
+	return tr, nil
 }


### PR DESCRIPTION
This PR adds support for RFC3161 timestamps when signing and verifying with the SPIFFE backend. This allows the produced bundles to outlive the SVID by providing the verifier with a way to check that the payload was signed during the leaf certificate validity period.

For now, when enabled, we piggyback on sigstore's TSA as we already have the trust roots in the @sigstore configs.

<img width="592" height="420" alt="image" src="https://github.com/user-attachments/assets/58a7102d-aaff-411e-9d7b-879dbcf42278" />


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>
