### PR TITLE
SVID validity option

### DIFF
--- a/options/spiffe_set.go
+++ b/options/spiffe_set.go
@@ -249,13 +249,22 @@ type SpiffeVerify struct {
 	// with Path.
 	PathRegex string
 
+	// SkipSVIDValidity disables enforcement of the leaf SVID's
+	// NotBefore/NotAfter dates. Default (false) is the safe
+	// behavior. Set true to validate the chain on cryptographic
+	// shape only — useful for archival verification of bundles whose
+	// SVIDs have rotated past their TTL, when the caller trusts the
+	// PKI chain alone. Bound to --<prefix>-skip-svid-validity.
+	SkipSVIDValidity bool
+
 	config *command.OptionsSetConfig
 }
 
 var _ command.OptionsSet = (*SpiffeVerify)(nil)
 
 // DefaultSpiffeVerify builds a SpiffeVerify sharing the supplied
-// common. Pass nil to allocate a fresh one.
+// common. Pass nil to allocate a fresh one. Defaults to enforcing
+// SVID validity dates; callers opt out by setting SkipSVIDValidity.
 func DefaultSpiffeVerify(common *SpiffeCommon) *SpiffeVerify {
 	if common == nil {
 		common = DefaultSpiffeCommon()
@@ -280,6 +289,10 @@ func (v *SpiffeVerify) Config() *command.OptionsSetConfig {
 					Long: "path-regex",
 					Help: "regex the SVID path must match (anchored; mutually exclusive with --spiffe-path)",
 				},
+				"skip-svid-validity": {
+					Long: "skip-svid-validity",
+					Help: "skip the leaf SVID's NotBefore/NotAfter check during chain validation; validates the cryptographic chain only (default off — date checks enforced)",
+				},
 			},
 		}
 	}
@@ -294,6 +307,7 @@ func (v *SpiffeVerify) AddFlags(cmd *cobra.Command) {
 	pf.StringVar(&v.TrustBundlePath, cfg.LongFlag("trust-bundle"), v.TrustBundlePath, cfg.HelpText("trust-bundle"))
 	pf.StringVar(&v.Path, cfg.LongFlag("path"), v.Path, cfg.HelpText("path"))
 	pf.StringVar(&v.PathRegex, cfg.LongFlag("path-regex"), v.PathRegex, cfg.HelpText("path-regex"))
+	pf.BoolVar(&v.SkipSVIDValidity, cfg.LongFlag("skip-svid-validity"), v.SkipSVIDValidity, cfg.HelpText("skip-svid-validity"))
 }
 
 // EffectiveTrustBundlePath returns the explicit TrustBundlePath when
@@ -356,6 +370,7 @@ func (v *SpiffeVerify) ApplyTo(target *Verification) error {
 	target.ExpectedTrustDomain = v.TrustDomain
 	target.ExpectedPath = v.Path
 	target.ExpectedPathRegex = v.PathRegex
+	target.SkipSVIDValidity = v.SkipSVIDValidity
 	return nil
 }
 

--- a/options/verification.go
+++ b/options/verification.go
@@ -42,6 +42,16 @@ type SpiffeVerification struct {
 	// ExpectedPathRegex, when non-empty, requires a regex match on the SVID's
 	// SPIFFE path component. Mutually exclusive with ExpectedPath.
 	ExpectedPathRegex string
+
+	// SkipSVIDValidity disables enforcement of the leaf SVID's
+	// NotBefore/NotAfter dates during chain validation. Default
+	// (false) is the safe behavior: the verifier checks the leaf is
+	// time-valid against either an RFC 3161 timestamp from the bundle
+	// or time.Now(). Set true to validate the chain using the leaf's
+	// NotBefore as the reference time, so the chain is checked purely
+	// on its cryptographic shape — useful for archival verification
+	// of bundles whose SVIDs have rotated.
+	SkipSVIDValidity bool
 }
 
 // WithExpectedIdentity serts the ExpectedIssuer and ExptectedSan options

--- a/spiffe/verifier/verifier.go
+++ b/spiffe/verifier/verifier.go
@@ -53,6 +53,18 @@ type VerifierOptions struct {
 	// Mutually exclusive with ExpectedPath.
 	ExpectedPathRegex *regexp.Regexp
 
+	// SkipSVIDValidity disables enforcement of the leaf SVID's
+	// NotBefore/NotAfter dates. Default (false) is the safe
+	// behavior: chain validation runs at either the TSA-verified
+	// timestamp or time.Now(). Set true to run chain validation at
+	// leaf.NotBefore — guaranteed valid for the leaf, and (assuming a
+	// well-formed chain where issuers were valid at issuance time)
+	// for the rest of the chain — so verification reduces to the
+	// cryptographic chain check alone. Setting this true also
+	// short-circuits TSA validation since there's no time check left
+	// to anchor the timestamp to.
+	SkipSVIDValidity bool
+
 	// TSAMaterialLoader, when non-nil, returns a TrustedMaterial used
 	// to validate any RFC 3161 timestamps embedded in the bundle.
 	// Called lazily on the first bundle that actually carries
@@ -129,7 +141,11 @@ func NewVerifierFromOptions(opts *options.SpiffeVerification) (*Verifier, error)
 	if err != nil {
 		return nil, fmt.Errorf("loading spiffe trust roots: %w", err)
 	}
-	vOpts := VerifierOptions{TrustRoots: pool, ExpectedPath: opts.ExpectedPath}
+	vOpts := VerifierOptions{
+		TrustRoots:       pool,
+		ExpectedPath:     opts.ExpectedPath,
+		SkipSVIDValidity: opts.SkipSVIDValidity,
+	}
 	if opts.ExpectedTrustDomain != "" {
 		td, err := spiffeid.TrustDomainFromString(opts.ExpectedTrustDomain)
 		if err != nil {
@@ -206,9 +222,23 @@ func (v *Verifier) Verify(opts *options.Verification, bndl *sbundle.Bundle) (*ve
 		intermediates.AddCert(c)
 	}
 
-	chainTime, verifiedTimestamps, err := v.chainValidationTime(bndl)
-	if err != nil {
-		return nil, err
+	var (
+		chainTime          time.Time
+		verifiedTimestamps []*root.Timestamp
+	)
+	if effective.SkipSVIDValidity {
+		// SVID-validity enforcement is off: validate the chain on
+		// crypto only, using a time guaranteed to be valid for the
+		// leaf. leaf.NotBefore is the issuance time, which a
+		// well-formed chain (issuers valid when issuing) accepts.
+		// TSA validation is intentionally skipped — there's no
+		// time check left to anchor.
+		chainTime = leaf.NotBefore
+	} else {
+		chainTime, verifiedTimestamps, err = v.chainValidationTime(bndl)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if _, err := leaf.Verify(x509.VerifyOptions{

--- a/spiffe/verifier/verifier_test.go
+++ b/spiffe/verifier/verifier_test.go
@@ -230,6 +230,82 @@ func TestVerifierAcceptsPathRegex(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// newExpiredTestPKI builds a CA + SVID where the leaf NotAfter is in
+// the past. Used to exercise VerifySVIDValidity=false.
+func newExpiredTestPKI(t *testing.T, path string) *testPKI {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-spire-root"},
+		NotBefore:             time.Now().Add(-2 * time.Hour),
+		NotAfter:              time.Now().Add(2 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTpl, rootTpl, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	rt, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	id := spiffeid.RequireFromPath(spiffeid.RequireTrustDomainFromString("example.org"), path)
+	leafTpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "svid"},
+		// Already expired by the time this test runs.
+		NotBefore:             time.Now().Add(-2 * time.Hour),
+		NotAfter:              time.Now().Add(-time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		URIs:                  []*url.URL{id.URL()},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTpl, rt, &leafKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	return &testPKI{root: rt, leaf: leaf, leafKey: leafKey}
+}
+
+// TestVerifierSkipSVIDValidityToggle confirms the SkipSVIDValidity
+// switch lets a caller validate a SPIFFE bundle whose SVID has already
+// expired — chain crypto remains intact, so the bundle is still
+// trustworthy if the caller is willing to skip the time check.
+func TestVerifierSkipSVIDValidityToggle(t *testing.T) {
+	t.Parallel()
+	pki := newExpiredTestPKI(t, "/workload")
+	bndl := makeSignedBundle(t, pki, testPayload)
+
+	t.Run("default-rejects-expired-svid", func(t *testing.T) {
+		t.Parallel()
+		v, err := NewVerifier(VerifierOptions{
+			TrustRoots: pki.rootPool(),
+			// SkipSVIDValidity left false — safe default.
+		})
+		require.NoError(t, err)
+		_, err = v.Verify(nil, bndl)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "chain verification failed")
+	})
+
+	t.Run("skip-accepts-expired-svid", func(t *testing.T) {
+		t.Parallel()
+		v, err := NewVerifier(VerifierOptions{
+			TrustRoots:       pki.rootPool(),
+			SkipSVIDValidity: true,
+		})
+		require.NoError(t, err)
+		res, err := v.Verify(nil, bndl)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+}
+
 func TestVerifierRejectsUntrustedRoot(t *testing.T) {
 	t.Parallel()
 	signer := newTestPKI(t, "/workload")


### PR DESCRIPTION
This PR adds a new option to control if the SVID validity check is enforcen when verifying. When enabled, the spiffe verifier will check the signature was done while the leaf cert was still in its validity interval.

When disabled, validation relies solely on the x509 chain.