### PR TITLE
Add source repository URI matching to sigstore identities

### DIFF
--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -608,8 +608,8 @@ func validateSigstore(s *IdentitySigstore) []error {
 			errs = append(errs, fmt.Errorf("source_repository_uri_match: %w", err))
 		}
 	}
-	// source_repository_uri has no legacy (plain-field) form, so setting it on
-	// a policy identity won't do what the author expects; require the matcher.
+	// source_repository_uri isn't supported by legacy mode so anyone setting it
+	// won't get what they expect. They must use the matcher instead.
 	if s.GetSourceRepositoryUri() != "" {
 		errs = append(errs, errors.New("source_repository_uri cannot be set on a policy identity; use source_repository_uri_match"))
 	}

--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -608,6 +608,9 @@ func validateSigstore(s *IdentitySigstore) []error {
 			errs = append(errs, fmt.Errorf("source_repository_uri_match: %w", err))
 		}
 	}
+	// source_repository_uri is verified-side data captured from the cert, not
+	// a pin. Reject it on a policy identity so a no-op constraint can't be
+	// mistaken for an origin-repo binding; pin via source_repository_uri_match.
 	if s.GetSourceRepositoryUri() != "" {
 		errs = append(errs, errors.New("source_repository_uri is verified-side data and cannot be set on a policy identity; use source_repository_uri_match"))
 	}

--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -608,11 +608,10 @@ func validateSigstore(s *IdentitySigstore) []error {
 			errs = append(errs, fmt.Errorf("source_repository_uri_match: %w", err))
 		}
 	}
-	// source_repository_uri is verified-side data captured from the cert, not
-	// a pin. Reject it on a policy identity so a no-op constraint can't be
-	// mistaken for an origin-repo binding; pin via source_repository_uri_match.
+	// source_repository_uri has no legacy form, so setting it on a policy
+	// identity has no effect; require source_repository_uri_match instead.
 	if s.GetSourceRepositoryUri() != "" {
-		errs = append(errs, errors.New("source_repository_uri is verified-side data and cannot be set on a policy identity; use source_repository_uri_match"))
+		errs = append(errs, errors.New("source_repository_uri cannot be set on a policy identity; use source_repository_uri_match"))
 	}
 	return errs
 }

--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -184,8 +184,9 @@ func (i *Identity) Principal() string {
 //
 // Spec covers the per-variant *_match conveniences and the dominant
 // principal-slot fields. It does NOT encode the outer Matchers slice,
-// IdentityKey.signing_fingerprint(_match), or IdentitySpiffe.trust_roots —
-// callers that need full fidelity should use the proto directly.
+// IdentityKey.signing_fingerprint(_match), IdentitySpiffe.trust_roots, or
+// IdentitySigstore.source_repository_uri(_match) — callers that need full
+// fidelity should use the proto directly.
 func (i *Identity) Spec() string {
 	switch {
 	case i.GetSigstore() != nil:
@@ -571,9 +572,9 @@ func validateSigstore(s *IdentitySigstore) []error {
 	var errs []error
 
 	useLegacy := s.GetIssuer() != "" || s.GetIdentity() != ""
-	useMatchers := s.GetIssuerMatch() != nil || s.GetIdentityMatch() != nil
+	useMatchers := s.GetIssuerMatch() != nil || s.GetIdentityMatch() != nil || s.GetSourceRepositoryUriMatch() != nil
 	if !useLegacy && !useMatchers {
-		errs = append(errs, errors.New("sigstore identity requires issuer, identity, issuer_match, or identity_match"))
+		errs = append(errs, errors.New("sigstore identity requires issuer, identity, issuer_match, identity_match, or source_repository_uri_match"))
 	}
 	if useLegacy && !useMatchers && (s.GetIssuer() == "" || s.GetIdentity() == "") {
 		errs = append(errs, errors.New("sigstore legacy form requires both issuer and identity when matchers are not used"))
@@ -601,6 +602,14 @@ func validateSigstore(s *IdentitySigstore) []error {
 		if err := validateStringMatcher(m); err != nil {
 			errs = append(errs, fmt.Errorf("identity_match: %w", err))
 		}
+	}
+	if m := s.GetSourceRepositoryUriMatch(); m != nil {
+		if err := validateStringMatcher(m); err != nil {
+			errs = append(errs, fmt.Errorf("source_repository_uri_match: %w", err))
+		}
+	}
+	if s.GetSourceRepositoryUri() != "" {
+		errs = append(errs, errors.New("source_repository_uri is verified-side data and cannot be set on a policy identity; use source_repository_uri_match"))
 	}
 	return errs
 }

--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -608,8 +608,8 @@ func validateSigstore(s *IdentitySigstore) []error {
 			errs = append(errs, fmt.Errorf("source_repository_uri_match: %w", err))
 		}
 	}
-	// source_repository_uri has no legacy form, so setting it on a policy
-	// identity has no effect; require source_repository_uri_match instead.
+	// source_repository_uri has no legacy (plain-field) form, so setting it on
+	// a policy identity won't do what the author expects; require the matcher.
 	if s.GetSourceRepositoryUri() != "" {
 		errs = append(errs, errors.New("source_repository_uri cannot be set on a policy identity; use source_repository_uri_match"))
 	}

--- a/api/v1/identity.pb.go
+++ b/api/v1/identity.pb.go
@@ -135,9 +135,11 @@ type IdentitySigstore struct {
 	// Convenience per-field matchers. When set, participate in the
 	// virtual matcher union alongside the legacy Mode/Issuer/Identity
 	// fields and the outer Matcher slice.
-	IssuerMatch              *StringMatcher `protobuf:"bytes,4,opt,name=issuer_match,json=issuerMatch,proto3" json:"issuer_match,omitempty"`
-	IdentityMatch            *StringMatcher `protobuf:"bytes,5,opt,name=identity_match,json=identityMatch,proto3" json:"identity_match,omitempty"`
-	SourceRepositoryUri      string         `protobuf:"bytes,6,opt,name=source_repository_uri,json=sourceRepositoryUri,proto3" json:"source_repository_uri,omitempty"` // Fulcio OID 1.3.6.1.4.1.57264.1.12
+	IssuerMatch   *StringMatcher `protobuf:"bytes,4,opt,name=issuer_match,json=issuerMatch,proto3" json:"issuer_match,omitempty"`
+	IdentityMatch *StringMatcher `protobuf:"bytes,5,opt,name=identity_match,json=identityMatch,proto3" json:"identity_match,omitempty"`
+	// Captured from the Fulcio cert during verification (OID
+	// 1.3.6.1.4.1.57264.1.12). Has no legacy form; pin via the matcher.
+	SourceRepositoryUri      string         `protobuf:"bytes,6,opt,name=source_repository_uri,json=sourceRepositoryUri,proto3" json:"source_repository_uri,omitempty"`
 	SourceRepositoryUriMatch *StringMatcher `protobuf:"bytes,7,opt,name=source_repository_uri_match,json=sourceRepositoryUriMatch,proto3" json:"source_repository_uri_match,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache

--- a/api/v1/identity.pb.go
+++ b/api/v1/identity.pb.go
@@ -135,10 +135,12 @@ type IdentitySigstore struct {
 	// Convenience per-field matchers. When set, participate in the
 	// virtual matcher union alongside the legacy Mode/Issuer/Identity
 	// fields and the outer Matcher slice.
-	IssuerMatch   *StringMatcher `protobuf:"bytes,4,opt,name=issuer_match,json=issuerMatch,proto3" json:"issuer_match,omitempty"`
-	IdentityMatch *StringMatcher `protobuf:"bytes,5,opt,name=identity_match,json=identityMatch,proto3" json:"identity_match,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	IssuerMatch              *StringMatcher `protobuf:"bytes,4,opt,name=issuer_match,json=issuerMatch,proto3" json:"issuer_match,omitempty"`
+	IdentityMatch            *StringMatcher `protobuf:"bytes,5,opt,name=identity_match,json=identityMatch,proto3" json:"identity_match,omitempty"`
+	SourceRepositoryUri      string         `protobuf:"bytes,6,opt,name=source_repository_uri,json=sourceRepositoryUri,proto3" json:"source_repository_uri,omitempty"` // Fulcio OID 1.3.6.1.4.1.57264.1.12
+	SourceRepositoryUriMatch *StringMatcher `protobuf:"bytes,7,opt,name=source_repository_uri_match,json=sourceRepositoryUriMatch,proto3" json:"source_repository_uri_match,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *IdentitySigstore) Reset() {
@@ -202,6 +204,20 @@ func (x *IdentitySigstore) GetIssuerMatch() *StringMatcher {
 func (x *IdentitySigstore) GetIdentityMatch() *StringMatcher {
 	if x != nil {
 		return x.IdentityMatch
+	}
+	return nil
+}
+
+func (x *IdentitySigstore) GetSourceRepositoryUri() string {
+	if x != nil {
+		return x.SourceRepositoryUri
+	}
+	return ""
+}
+
+func (x *IdentitySigstore) GetSourceRepositoryUriMatch() *StringMatcher {
+	if x != nil {
+		return x.SourceRepositoryUriMatch
 	}
 	return nil
 }
@@ -454,13 +470,15 @@ const file_carabiner_signer_v1_identity_proto_rawDesc = "" +
 	"\t_sigstoreB\x06\n" +
 	"\x04_keyB\x06\n" +
 	"\x04_refB\t\n" +
-	"\a_spiffe\"\xfa\x01\n" +
+	"\a_spiffe\"\x91\x03\n" +
 	"\x10IdentitySigstore\x12\x17\n" +
 	"\x04mode\x18\x01 \x01(\tH\x00R\x04mode\x88\x01\x01\x12\x16\n" +
 	"\x06issuer\x18\x02 \x01(\tR\x06issuer\x12\x1a\n" +
 	"\bidentity\x18\x03 \x01(\tR\bidentity\x12E\n" +
 	"\fissuer_match\x18\x04 \x01(\v2\".carabiner.signer.v1.StringMatcherR\vissuerMatch\x12I\n" +
-	"\x0eidentity_match\x18\x05 \x01(\v2\".carabiner.signer.v1.StringMatcherR\ridentityMatchB\a\n" +
+	"\x0eidentity_match\x18\x05 \x01(\v2\".carabiner.signer.v1.StringMatcherR\ridentityMatch\x122\n" +
+	"\x15source_repository_uri\x18\x06 \x01(\tR\x13sourceRepositoryUri\x12a\n" +
+	"\x1bsource_repository_uri_match\x18\a \x01(\v2\".carabiner.signer.v1.StringMatcherR\x18sourceRepositoryUriMatchB\a\n" +
 	"\x05_mode\"\xd8\x02\n" +
 	"\vIdentityKey\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -514,17 +532,18 @@ var file_carabiner_signer_v1_identity_proto_depIdxs = []int32{
 	5,  // 4: carabiner.signer.v1.Identity.matchers:type_name -> carabiner.signer.v1.Matcher
 	6,  // 5: carabiner.signer.v1.IdentitySigstore.issuer_match:type_name -> carabiner.signer.v1.StringMatcher
 	6,  // 6: carabiner.signer.v1.IdentitySigstore.identity_match:type_name -> carabiner.signer.v1.StringMatcher
-	6,  // 7: carabiner.signer.v1.IdentityKey.id_match:type_name -> carabiner.signer.v1.StringMatcher
-	6,  // 8: carabiner.signer.v1.IdentityKey.type_match:type_name -> carabiner.signer.v1.StringMatcher
-	6,  // 9: carabiner.signer.v1.IdentityKey.signing_fingerprint_match:type_name -> carabiner.signer.v1.StringMatcher
-	6,  // 10: carabiner.signer.v1.IdentitySpiffe.svid_match:type_name -> carabiner.signer.v1.StringMatcher
-	6,  // 11: carabiner.signer.v1.IdentitySpiffe.trust_domain_match:type_name -> carabiner.signer.v1.StringMatcher
-	6,  // 12: carabiner.signer.v1.IdentitySpiffe.path_match:type_name -> carabiner.signer.v1.StringMatcher
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	6,  // 7: carabiner.signer.v1.IdentitySigstore.source_repository_uri_match:type_name -> carabiner.signer.v1.StringMatcher
+	6,  // 8: carabiner.signer.v1.IdentityKey.id_match:type_name -> carabiner.signer.v1.StringMatcher
+	6,  // 9: carabiner.signer.v1.IdentityKey.type_match:type_name -> carabiner.signer.v1.StringMatcher
+	6,  // 10: carabiner.signer.v1.IdentityKey.signing_fingerprint_match:type_name -> carabiner.signer.v1.StringMatcher
+	6,  // 11: carabiner.signer.v1.IdentitySpiffe.svid_match:type_name -> carabiner.signer.v1.StringMatcher
+	6,  // 12: carabiner.signer.v1.IdentitySpiffe.trust_domain_match:type_name -> carabiner.signer.v1.StringMatcher
+	6,  // 13: carabiner.signer.v1.IdentitySpiffe.path_match:type_name -> carabiner.signer.v1.StringMatcher
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_carabiner_signer_v1_identity_proto_init() }

--- a/api/v1/identity.pb.go
+++ b/api/v1/identity.pb.go
@@ -137,9 +137,8 @@ type IdentitySigstore struct {
 	// fields and the outer Matcher slice.
 	IssuerMatch   *StringMatcher `protobuf:"bytes,4,opt,name=issuer_match,json=issuerMatch,proto3" json:"issuer_match,omitempty"`
 	IdentityMatch *StringMatcher `protobuf:"bytes,5,opt,name=identity_match,json=identityMatch,proto3" json:"identity_match,omitempty"`
-	// Captured from the Fulcio cert during verification (OID
-	// 1.3.6.1.4.1.57264.1.12). Has no legacy form; pin via the matcher.
-	SourceRepositoryUri      string         `protobuf:"bytes,6,opt,name=source_repository_uri,json=sourceRepositoryUri,proto3" json:"source_repository_uri,omitempty"`
+	// Has no legacy form; pin via source_repository_uri_match.
+	SourceRepositoryUri      string         `protobuf:"bytes,6,opt,name=source_repository_uri,json=sourceRepositoryUri,proto3" json:"source_repository_uri,omitempty"` // OID 1.3.6.1.4.1.57264.1.12
 	SourceRepositoryUriMatch *StringMatcher `protobuf:"bytes,7,opt,name=source_repository_uri_match,json=sourceRepositoryUriMatch,proto3" json:"source_repository_uri_match,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache

--- a/api/v1/identity_test.go
+++ b/api/v1/identity_test.go
@@ -146,6 +146,26 @@ func TestVerifyIdentity(t *testing.T) {
 				},
 			},
 		}},
+		{"sigstore-source-repo-match-only-valid", false, &Identity{
+			Sigstore: &IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://github.com/myorg/repo"},
+				},
+			},
+		}},
+		{"sigstore-source-repo-match-bad-regex", true, &Identity{
+			Sigstore: &IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Regex{Regex: "[unclosed"},
+				},
+			},
+		}},
+		{"sigstore-source-repo-data-on-expectation-invalid", true, &Identity{
+			Sigstore: &IdentitySigstore{
+				IdentityMatch:       &StringMatcher{Kind: &StringMatcher_Exact{Exact: "user@example.com"}},
+				SourceRepositoryUri: "https://github.com/myorg/repo",
+			},
+		}},
 		{"key-id-match-valid", false, &Identity{
 			Key: &IdentityKey{
 				IdMatch: &StringMatcher{

--- a/api/v1/matcher.pb.go
+++ b/api/v1/matcher.pb.go
@@ -30,6 +30,7 @@ const (
 //	"principal"                  // the whole principal string
 //	"sigstore.issuer"
 //	"sigstore.identity"
+//	"sigstore.source_repository_uri"
 //	"key.id"
 //	"key.type"
 //	"key.signing_fingerprint"

--- a/api/v1/verification.go
+++ b/api/v1/verification.go
@@ -57,7 +57,7 @@ func SignatureVerificationFromResult(r *verify.VerificationResult) *SignatureVer
 	case san != "" || issuer != "":
 		ss := &IdentitySigstore{Issuer: issuer, Identity: san}
 		if r.Signature != nil && r.Signature.Certificate != nil {
-			ss.SourceRepositoryUri = r.Signature.Certificate.Extensions.SourceRepositoryURI
+			ss.SourceRepositoryUri = r.Signature.Certificate.SourceRepositoryURI
 		}
 		sv.Identities = append(sv.Identities, &Identity{Sigstore: ss})
 	}

--- a/api/v1/verification.go
+++ b/api/v1/verification.go
@@ -55,9 +55,11 @@ func SignatureVerificationFromResult(r *verify.VerificationResult) *SignatureVer
 		}
 		sv.Identities = append(sv.Identities, &Identity{Spiffe: id})
 	case san != "" || issuer != "":
-		sv.Identities = append(sv.Identities, &Identity{
-			Sigstore: &IdentitySigstore{Issuer: issuer, Identity: san},
-		})
+		ss := &IdentitySigstore{Issuer: issuer, Identity: san}
+		if r.Signature != nil && r.Signature.Certificate != nil {
+			ss.SourceRepositoryUri = r.Signature.Certificate.Extensions.SourceRepositoryURI
+		}
+		sv.Identities = append(sv.Identities, &Identity{Sigstore: ss})
 	}
 	return sv
 }
@@ -174,9 +176,10 @@ func sigstoreCheck(id *IdentitySigstore) (func(*Identity) bool, bool) {
 	identityLegacy := id.GetIdentity()
 	issuerMatch := id.GetIssuerMatch()
 	identityMatch := id.GetIdentityMatch()
+	sourceRepoMatch := id.GetSourceRepositoryUriMatch()
 
 	useLegacy := issuerLegacy != "" || identityLegacy != ""
-	useMatchers := issuerMatch != nil || identityMatch != nil
+	useMatchers := issuerMatch != nil || identityMatch != nil || sourceRepoMatch != nil
 	if !useLegacy && !useMatchers {
 		return nil, false
 	}
@@ -233,6 +236,9 @@ func sigstoreCheck(id *IdentitySigstore) (func(*Identity) bool, bool) {
 			return false
 		}
 		if identityMatch != nil && !matchString(identityMatch, signerIdentity) {
+			return false
+		}
+		if sourceRepoMatch != nil && !matchString(sourceRepoMatch, ss.GetSourceRepositoryUri()) {
 			return false
 		}
 		return true
@@ -355,6 +361,8 @@ func resolveIdentityField(signer *Identity, field string) (string, bool) {
 			return ss.GetIssuer(), true
 		case "identity":
 			return ss.GetIdentity(), true
+		case "source_repository_uri":
+			return ss.GetSourceRepositoryUri(), true
 		}
 	case identityTypeKey:
 		k := signer.GetKey()

--- a/api/v1/verification_test.go
+++ b/api/v1/verification_test.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/require"
 )
@@ -214,8 +215,9 @@ func TestMatchesSigstoreIdentityConvenienceMatchers(t *testing.T) {
 	t.Parallel()
 	signer := &SignatureVerification{
 		Identities: []*Identity{{Sigstore: &IdentitySigstore{
-			Issuer:   "https://token.actions.githubusercontent.com",
-			Identity: "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+			Issuer:              "https://token.actions.githubusercontent.com",
+			Identity:            "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+			SourceRepositoryUri: "https://github.com/myorg/repo",
 		}}},
 	}
 	for _, tt := range []struct {
@@ -275,6 +277,57 @@ func TestMatchesSigstoreIdentityConvenienceMatchers(t *testing.T) {
 				},
 			},
 			true,
+		},
+		{
+			"source-repo-match-only-positive",
+			&IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://github.com/myorg/repo"},
+				},
+			},
+			true,
+		},
+		{
+			"source-repo-match-prefix-positive",
+			&IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Prefix{Prefix: "https://github.com/myorg/"},
+				},
+			},
+			true,
+		},
+		{
+			"source-repo-match-only-wrong-value",
+			&IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://github.com/other/repo"},
+				},
+			},
+			false,
+		},
+		{
+			"source-repo-match-combined-with-issuer-and",
+			&IdentitySigstore{
+				IssuerMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://token.actions.githubusercontent.com"},
+				},
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://github.com/myorg/repo"},
+				},
+			},
+			true,
+		},
+		{
+			"source-repo-match-combined-issuer-ok-repo-wrong",
+			&IdentitySigstore{
+				IssuerMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://token.actions.githubusercontent.com"},
+				},
+				SourceRepositoryUriMatch: &StringMatcher{
+					Kind: &StringMatcher_Exact{Exact: "https://github.com/other/repo"},
+				},
+			},
+			false,
 		},
 		{
 			"no-constraint-at-all-rejected",
@@ -393,8 +446,9 @@ func TestMatchesIdentityOuterMatchers(t *testing.T) {
 
 	sigstoreSigner := &SignatureVerification{
 		Identities: []*Identity{{Sigstore: &IdentitySigstore{
-			Issuer:   "https://token.actions.githubusercontent.com",
-			Identity: "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+			Issuer:              "https://token.actions.githubusercontent.com",
+			Identity:            "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+			SourceRepositoryUri: "https://github.com/myorg/repo",
 		}}},
 	}
 	spiffeSigner := &SignatureVerification{
@@ -548,6 +602,34 @@ func TestMatchesIdentityOuterMatchers(t *testing.T) {
 				},
 			},
 			true,
+		},
+		{
+			"outer-source-repo-matches",
+			sigstoreSigner,
+			&Identity{
+				Sigstore: &IdentitySigstore{
+					Issuer:   "https://token.actions.githubusercontent.com",
+					Identity: "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+				},
+				Matchers: []*Matcher{
+					stringMatch("sigstore.source_repository_uri", "https://github.com/myorg/repo"),
+				},
+			},
+			true,
+		},
+		{
+			"outer-source-repo-mismatch",
+			sigstoreSigner,
+			&Identity{
+				Sigstore: &IdentitySigstore{
+					Issuer:   "https://token.actions.githubusercontent.com",
+					Identity: "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+				},
+				Matchers: []*Matcher{
+					stringMatch("sigstore.source_repository_uri", "https://github.com/other/repo"),
+				},
+			},
+			false,
 		},
 		{
 			"unknown-field-fails-closed",
@@ -801,6 +883,69 @@ func TestSignatureVerificationFromResult(t *testing.T) {
 		require.NotNil(t, ss)
 		require.Equal(t, "https://accounts.google.com", ss.GetIssuer())
 		require.Equal(t, "user@example.com", ss.GetIdentity())
+	})
+
+	t.Run("fulcio-captures-source-repository-uri", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{
+			VerifiedIdentity: &verify.CertificateIdentity{
+				SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: "https://github.com/myorg/repo/.github/workflows/release.yml@refs/tags/v1.2.3",
+				},
+				Issuer: verify.IssuerMatcher{Issuer: "https://token.actions.githubusercontent.com"},
+			},
+			Signature: &verify.SignatureVerificationResult{
+				Certificate: &certificate.Summary{
+					Extensions: certificate.Extensions{
+						SourceRepositoryURI: "https://github.com/myorg/repo",
+					},
+				},
+			},
+		})
+		require.True(t, sv.GetVerified())
+		require.Len(t, sv.GetIdentities(), 1)
+		ss := sv.GetIdentities()[0].GetSigstore()
+		require.NotNil(t, ss)
+		require.Equal(t, "https://github.com/myorg/repo", ss.GetSourceRepositoryUri())
+	})
+
+	t.Run("fulcio-no-signature-empty-source-repo", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{
+			VerifiedIdentity: &verify.CertificateIdentity{
+				SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: "user@example.com",
+				},
+				Issuer: verify.IssuerMatcher{Issuer: "https://accounts.google.com"},
+			},
+		})
+		require.True(t, sv.GetVerified())
+		require.Len(t, sv.GetIdentities(), 1)
+		ss := sv.GetIdentities()[0].GetSigstore()
+		require.NotNil(t, ss)
+		require.Empty(t, ss.GetSourceRepositoryUri())
+	})
+
+	t.Run("spiffe-san-with-cert-does-not-capture-source-repo", func(t *testing.T) {
+		t.Parallel()
+		sv := SignatureVerificationFromResult(&verify.VerificationResult{
+			VerifiedIdentity: &verify.CertificateIdentity{
+				SubjectAlternativeName: verify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: "spiffe://example.org/workload",
+				},
+			},
+			Signature: &verify.SignatureVerificationResult{
+				Certificate: &certificate.Summary{
+					Extensions: certificate.Extensions{
+						SourceRepositoryURI: "https://github.com/myorg/repo",
+					},
+				},
+			},
+		})
+		require.True(t, sv.GetVerified())
+		require.Len(t, sv.GetIdentities(), 1)
+		require.NotNil(t, sv.GetIdentities()[0].GetSpiffe())
+		require.Nil(t, sv.GetIdentities()[0].GetSigstore())
 	})
 
 	t.Run("result-without-verified-identity", func(t *testing.T) {

--- a/docs/identity-matching.md
+++ b/docs/identity-matching.md
@@ -125,6 +125,7 @@ against any variant. Other paths are variant-qualified:
 | `principal`             | `Identity.Principal()` — works for any variant                            |
 | `sigstore.issuer`       | `Sigstore.Issuer` (signer must be sigstore)                               |
 | `sigstore.identity`     | `Sigstore.Identity`                                                       |
+| `sigstore.source_repository_uri` | `Sigstore.SourceRepositoryUri`                                   |
 | `key.id`                | `Key.Id`                                                                  |
 | `key.type`              | `Key.Type`                                                                |
 | `key.signing_fingerprint` | `Key.SigningFingerprint`                                                |
@@ -147,6 +148,8 @@ the matcher **fails closed** for that signer.
 | `Mode`          | `exact` (default) or `regexp` — applies to legacy `Issuer`/`Identity`.    |
 | `IssuerMatch`   | `StringMatcher` applied to the signer's issuer.                           |
 | `IdentityMatch` | `StringMatcher` applied to the signer's identity.                         |
+| `SourceRepositoryUri` | Source repository URI captured from the Fulcio cert (verified-side data). Pinned only via `SourceRepositoryUriMatch`; setting it on a policy identity is rejected at validation. |
+| `SourceRepositoryUriMatch` | `StringMatcher` applied to the signer's source repository URI. |
 
 ### Matching rules (new + legacy combined)
 

--- a/docs/identity-matching.md
+++ b/docs/identity-matching.md
@@ -148,7 +148,7 @@ the matcher **fails closed** for that signer.
 | `Mode`          | `exact` (default) or `regexp` — applies to legacy `Issuer`/`Identity`.    |
 | `IssuerMatch`   | `StringMatcher` applied to the signer's issuer.                           |
 | `IdentityMatch` | `StringMatcher` applied to the signer's identity.                         |
-| `SourceRepositoryUri` | Source repository URI captured from the Fulcio cert (verified-side data). Pinned only via `SourceRepositoryUriMatch`; setting it on a policy identity is rejected at validation. |
+| `SourceRepositoryUri` | Source repository URI captured from the Fulcio cert (verified-side data; not a pin — see matching rules). |
 | `SourceRepositoryUriMatch` | `StringMatcher` applied to the signer's source repository URI. |
 
 ### Matching rules (new + legacy combined)
@@ -166,6 +166,16 @@ new capability over the legacy shape.
 
 Legacy and matchers combine with AND semantics: all set constraints
 must pass.
+
+`SourceRepositoryUri` is verified-side data captured from the
+certificate, never a pin. Setting it on a policy identity is rejected
+(rather than silently ignored) so an author meaning to constrain the
+origin repo can't accidentally write a no-op — pin it with
+`SourceRepositoryUriMatch`. All identity extensions (SAN, issuer,
+source repository) live on the same leaf certificate, so they share one
+signer; a matcher-only policy still leaves the issuer unconstrained, so
+combine `SourceRepositoryUriMatch` with an issuer/identity pin when the
+origin issuer matters.
 
 ### Example — new form
 

--- a/docs/identity-matching.md
+++ b/docs/identity-matching.md
@@ -148,7 +148,6 @@ the matcher **fails closed** for that signer.
 | `Mode`          | `exact` (default) or `regexp` — applies to legacy `Issuer`/`Identity`.    |
 | `IssuerMatch`   | `StringMatcher` applied to the signer's issuer.                           |
 | `IdentityMatch` | `StringMatcher` applied to the signer's identity.                         |
-| `SourceRepositoryUri` | Source repository URI captured from the Fulcio cert (verified-side data; not a pin — see matching rules). |
 | `SourceRepositoryUriMatch` | `StringMatcher` applied to the signer's source repository URI. |
 
 ### Matching rules (new + legacy combined)
@@ -166,16 +165,6 @@ new capability over the legacy shape.
 
 Legacy and matchers combine with AND semantics: all set constraints
 must pass.
-
-`SourceRepositoryUri` is verified-side data captured from the
-certificate, never a pin. Setting it on a policy identity is rejected
-(rather than silently ignored) so an author meaning to constrain the
-origin repo can't accidentally write a no-op — pin it with
-`SourceRepositoryUriMatch`. All identity extensions (SAN, issuer,
-source repository) live on the same leaf certificate, so they share one
-signer; a matcher-only policy still leaves the issuer unconstrained, so
-combine `SourceRepositoryUriMatch` with an issuer/identity pin when the
-origin issuer matters.
 
 ### Example — new form
 

--- a/proto/carabiner/signer/v1/identity.proto
+++ b/proto/carabiner/signer/v1/identity.proto
@@ -46,6 +46,9 @@ message IdentitySigstore {
     // fields and the outer Matcher slice.
     StringMatcher issuer_match   = 4;
     StringMatcher identity_match = 5;
+
+    string source_repository_uri              = 6; // Fulcio OID 1.3.6.1.4.1.57264.1.12
+    StringMatcher source_repository_uri_match = 7;
 }
 
 // IdentityKey registers the data of a key used to sign attestations.

--- a/proto/carabiner/signer/v1/identity.proto
+++ b/proto/carabiner/signer/v1/identity.proto
@@ -47,9 +47,8 @@ message IdentitySigstore {
     StringMatcher issuer_match   = 4;
     StringMatcher identity_match = 5;
 
-    // Captured from the Fulcio cert during verification (OID
-    // 1.3.6.1.4.1.57264.1.12). Has no legacy form; pin via the matcher.
-    string source_repository_uri              = 6;
+    // Has no legacy form; pin via source_repository_uri_match.
+    string source_repository_uri              = 6; // OID 1.3.6.1.4.1.57264.1.12
     StringMatcher source_repository_uri_match = 7;
 }
 

--- a/proto/carabiner/signer/v1/identity.proto
+++ b/proto/carabiner/signer/v1/identity.proto
@@ -47,7 +47,9 @@ message IdentitySigstore {
     StringMatcher issuer_match   = 4;
     StringMatcher identity_match = 5;
 
-    string source_repository_uri              = 6; // Fulcio OID 1.3.6.1.4.1.57264.1.12
+    // Captured from the Fulcio cert during verification (OID
+    // 1.3.6.1.4.1.57264.1.12). Has no legacy form; pin via the matcher.
+    string source_repository_uri              = 6;
     StringMatcher source_repository_uri_match = 7;
 }
 

--- a/proto/carabiner/signer/v1/matcher.proto
+++ b/proto/carabiner/signer/v1/matcher.proto
@@ -12,6 +12,7 @@ option go_package = "github.com/carabiner-dev/signer/api/v1";
 //   "principal"                  // the whole principal string
 //   "sigstore.issuer"
 //   "sigstore.identity"
+//   "sigstore.source_repository_uri"
 //   "key.id"
 //   "key.type"
 //   "key.signing_fingerprint"

--- a/signer_e2e_test.go
+++ b/signer_e2e_test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/carabiner-dev/signer/options"
 )
 
-// TestSignAndVerifyE2E performs a real end-to-end signing and verification
-// against the sigstore public good instance. It requires GitHub Actions
-// OIDC tokens to be available.
+// TestSignAndVerifyE2E signs in a GitHub Actions workflow and verifies the
+// bundle two ways: skipping the identity check, and pinning the exact issuer/SAN
+// so the source repository URI (Fulcio OID 1.3.6.1.4.1.57264.1.12) is captured
+// and matchable. Requires GitHub Actions OIDC tokens.
 func TestSignAndVerifyE2E(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("GITHUB_ACTIONS") != "true" {
@@ -34,48 +35,22 @@ func TestSignAndVerifyE2E(t *testing.T) {
 	require.NotNil(t, bndl)
 
 	v := NewVerifier()
+
+	// Verify skipping the identity check. The result still carries the cert
+	// summary, which we use to pin the exact identity below.
 	res, err := v.VerifyParsedBundle(bndl, options.WithSkipIdentityCheck(true))
 	require.NoError(t, err)
-	require.NotNil(t, res)
-}
+	require.NotNil(t, res.Signature)
+	require.NotNil(t, res.Signature.Certificate)
 
-// TestSignAndVerifySourceRepositoryE2E signs in a GitHub Actions workflow and
-// checks that the source repository URI captured from the Fulcio cert (OID
-// 1.3.6.1.4.1.57264.1.12) is the repo running the workflow, and that
-// source_repository_uri_match pins it. Verifying against the Actions OIDC
-// issuer populates the VerifiedIdentity the capture reads from.
-func TestSignAndVerifySourceRepositoryE2E(t *testing.T) {
-	t.Parallel()
-	if os.Getenv("GITHUB_ACTIONS") != "true" {
-		t.Skip("(not running in an actions workflow)")
-	}
-	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" {
-		t.Skip("(OIDC tokens not available)")
-	}
-	s := NewSigner()
-	statementData, err := os.ReadFile("bundle/testdata/statement.json")
-	require.NoError(t, err)
-	bndl, err := s.SignStatementBundle(statementData)
-	require.NoError(t, err)
-	require.NotNil(t, bndl)
-
-	v := NewVerifier()
-
-	// Read the signing identity (issuer + workflow SAN) so we can pin it
-	// exactly on the real verification, the way a consumer that knows its
-	// expected signer does. SignatureVerificationFromResult only surfaces an
-	// identity when the verification pinned an exact issuer/SAN.
-	probe, err := v.VerifyParsedBundle(bndl, options.WithSkipIdentityCheck(true))
-	require.NoError(t, err)
-	require.NotNil(t, probe.Signature)
-	require.NotNil(t, probe.Signature.Certificate)
-	issuer := probe.Signature.Certificate.Issuer
-	san := probe.Signature.Certificate.SubjectAlternativeName
+	// Pin the exact issuer/SAN (which SignatureVerificationFromResult needs to
+	// surface an identity), then check the captured source repo and the matcher.
+	issuer := res.Signature.Certificate.Issuer
+	san := res.Signature.Certificate.SubjectAlternativeName
 	require.NotEmpty(t, san)
 
-	res, err := v.VerifyParsedBundle(bndl, options.WithExpectedIdentity(issuer, san))
+	res, err = v.VerifyParsedBundle(bndl, options.WithExpectedIdentity(issuer, san))
 	require.NoError(t, err)
-	require.NotNil(t, res)
 
 	sv := api.SignatureVerificationFromResult(res)
 	require.NotEmpty(t, sv.GetIdentities())

--- a/signer_e2e_test.go
+++ b/signer_e2e_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	api "github.com/carabiner-dev/signer/api/v1"
 	"github.com/carabiner-dev/signer/options"
 )
 
@@ -36,4 +37,47 @@ func TestSignAndVerifyE2E(t *testing.T) {
 	res, err := v.VerifyParsedBundle(bndl, options.WithSkipIdentityCheck(true))
 	require.NoError(t, err)
 	require.NotNil(t, res)
+}
+
+// TestSignAndVerifySourceRepositoryE2E signs in a GitHub Actions workflow and
+// checks that the source repository URI captured from the Fulcio cert (OID
+// 1.3.6.1.4.1.57264.1.12) is the repo running the workflow, and that
+// source_repository_uri_match pins it. Verifying against the Actions OIDC
+// issuer populates the VerifiedIdentity the capture reads from.
+func TestSignAndVerifySourceRepositoryE2E(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		t.Skip("(not running in an actions workflow)")
+	}
+	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" {
+		t.Skip("(OIDC tokens not available)")
+	}
+	s := NewSigner()
+	statementData, err := os.ReadFile("bundle/testdata/statement.json")
+	require.NoError(t, err)
+	bndl, err := s.SignStatementBundle(statementData)
+	require.NoError(t, err)
+	require.NotNil(t, bndl)
+
+	v := NewVerifier()
+	res, err := v.VerifyParsedBundle(bndl, options.WithExpectedIdentityRegex(
+		`^https://token\.actions\.githubusercontent\.com$`, `.*`,
+	))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	sv := api.SignatureVerificationFromResult(res)
+	require.NotEmpty(t, sv.GetIdentities())
+	ss := sv.GetIdentities()[0].GetSigstore()
+	require.NotNil(t, ss)
+
+	wantRepo := os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY")
+	require.Equal(t, wantRepo, ss.GetSourceRepositoryUri())
+
+	require.True(t, sv.MatchesSigstoreIdentity(&api.IdentitySigstore{
+		SourceRepositoryUriMatch: &api.StringMatcher{Kind: &api.StringMatcher_Exact{Exact: wantRepo}},
+	}))
+	require.False(t, sv.MatchesSigstoreIdentity(&api.IdentitySigstore{
+		SourceRepositoryUriMatch: &api.StringMatcher{Kind: &api.StringMatcher_Exact{Exact: "https://github.com/evil/repo"}},
+	}))
 }

--- a/signer_e2e_test.go
+++ b/signer_e2e_test.go
@@ -11,14 +11,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	api "github.com/carabiner-dev/signer/api/v1"
 	"github.com/carabiner-dev/signer/options"
 )
 
-// TestSignAndVerifyE2E signs in a GitHub Actions workflow and verifies the
-// bundle two ways: skipping the identity check, and pinning the exact issuer/SAN
-// so the source repository URI (Fulcio OID 1.3.6.1.4.1.57264.1.12) is captured
-// and matchable. Requires GitHub Actions OIDC tokens.
+// TestSignAndVerifyE2E performs a real end-to-end signing and verification
+// against the sigstore public good instance. It requires GitHub Actions
+// OIDC tokens to be available.
 func TestSignAndVerifyE2E(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("GITHUB_ACTIONS") != "true" {
@@ -35,35 +33,7 @@ func TestSignAndVerifyE2E(t *testing.T) {
 	require.NotNil(t, bndl)
 
 	v := NewVerifier()
-
-	// Verify skipping the identity check. The result still carries the cert
-	// summary, which we use to pin the exact identity below.
 	res, err := v.VerifyParsedBundle(bndl, options.WithSkipIdentityCheck(true))
 	require.NoError(t, err)
-	require.NotNil(t, res.Signature)
-	require.NotNil(t, res.Signature.Certificate)
-
-	// Pin the exact issuer/SAN (which SignatureVerificationFromResult needs to
-	// surface an identity), then check the captured source repo and the matcher.
-	issuer := res.Signature.Certificate.Issuer
-	san := res.Signature.Certificate.SubjectAlternativeName
-	require.NotEmpty(t, san)
-
-	res, err = v.VerifyParsedBundle(bndl, options.WithExpectedIdentity(issuer, san))
-	require.NoError(t, err)
-
-	sv := api.SignatureVerificationFromResult(res)
-	require.NotEmpty(t, sv.GetIdentities())
-	ss := sv.GetIdentities()[0].GetSigstore()
-	require.NotNil(t, ss)
-
-	wantRepo := os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY")
-	require.Equal(t, wantRepo, ss.GetSourceRepositoryUri())
-
-	require.True(t, sv.MatchesSigstoreIdentity(&api.IdentitySigstore{
-		SourceRepositoryUriMatch: &api.StringMatcher{Kind: &api.StringMatcher_Exact{Exact: wantRepo}},
-	}))
-	require.False(t, sv.MatchesSigstoreIdentity(&api.IdentitySigstore{
-		SourceRepositoryUriMatch: &api.StringMatcher{Kind: &api.StringMatcher_Exact{Exact: "https://github.com/evil/repo"}},
-	}))
+	require.NotNil(t, res)
 }

--- a/signer_e2e_test.go
+++ b/signer_e2e_test.go
@@ -60,9 +60,20 @@ func TestSignAndVerifySourceRepositoryE2E(t *testing.T) {
 	require.NotNil(t, bndl)
 
 	v := NewVerifier()
-	res, err := v.VerifyParsedBundle(bndl, options.WithExpectedIdentityRegex(
-		`^https://token\.actions\.githubusercontent\.com$`, `.*`,
-	))
+
+	// Read the signing identity (issuer + workflow SAN) so we can pin it
+	// exactly on the real verification, the way a consumer that knows its
+	// expected signer does. SignatureVerificationFromResult only surfaces an
+	// identity when the verification pinned an exact issuer/SAN.
+	probe, err := v.VerifyParsedBundle(bndl, options.WithSkipIdentityCheck(true))
+	require.NoError(t, err)
+	require.NotNil(t, probe.Signature)
+	require.NotNil(t, probe.Signature.Certificate)
+	issuer := probe.Signature.Certificate.Issuer
+	san := probe.Signature.Certificate.SubjectAlternativeName
+	require.NotEmpty(t, san)
+
+	res, err := v.VerifyParsedBundle(bndl, options.WithExpectedIdentity(issuer, san))
 	require.NoError(t, err)
 	require.NotNil(t, res)
 


### PR DESCRIPTION
Lets a policy pin the origin repo from a Fulcio cert (OID 1.3.6.1.4.1.57264.1.12) alongside the issuer/SAN. Adds source_repository_uri + a source_repository_uri_match matcher to IdentitySigstore, following the
existing issuer/issuer_match + identity/identity_match shape.

A few notes:
- Value comes from the verified leaf cert (result.Signature.Certificate), not the matched/expected identity.
- Verified-side data, pinned only via the matcher — same treatment as signing_fingerprint (no legacy Mode/regexp, not in the slug grammar).
- validateSigstore rejects the plain source_repository_uri if it's set on a policy identity, since otherwise it silently does nothing. Heads up: signing_fingerprint/type have the same latent footgun and
currently don't reject — happy to generalize that guard if you want, or leave it scoped to this field.

Tested with unit tests (capture / match / validate) + an e2e that signs in CI and checks the captured repo and the matcher.

Two things to flag (not touched here):
1. signing_fingerprint/type have the same "plain field silently ignored on a policy identity" footgun and don't reject the way source_repository_uri now does.  We could fix that now if you want or file an issue.
2. SignatureVerificationFromResult only surfaces an identity (incl. source_repo) when verification pinned an exact issuer/SAN — not under a regex pin or skip-identity — because it reads the matched expected
identity. Pre-existing (same for issuer/identity); reading from the cert summary instead would fix it for all of them. Can do that as a follow-up. Doesn't affect the ampel path.

### Why?

There could be three parties involved in building software and verifying it with Ampel.

1. The adopter that's trying to ship & verify software.
2. An intermediate reusable workflow owned by another project that runs Ampel to produce VSAs.
3. Ampel itself.

Currently signer (and ampel) only lets us verify the identities of 2 and 3 but we still want to know what repo the software came from (e.g. the identity in 1).

### Next

2 more PRs coming. One to the collector repo and one to Ampel itself.