### PR TITLE
Add from_context to StringMatcher for caller-resolved values

### DIFF
--- a/api/v1/identity.go
+++ b/api/v1/identity.go
@@ -690,8 +690,16 @@ func validateMatcher(m *Matcher) error {
 }
 
 // validateStringMatcher ensures regex patterns compile and glob patterns
-// are well-formed. Exact/Prefix kinds have no format requirements.
+// are well-formed. Exact/Prefix kinds have no format requirements. A
+// from_context binding is valid on its own (the caller resolves it) but cannot
+// be combined with a match kind.
 func validateStringMatcher(m *StringMatcher) error {
+	if m.GetFromContext() != "" {
+		if m.GetKind() != nil {
+			return errors.New("from_context cannot be combined with a match kind")
+		}
+		return nil
+	}
 	switch kind := m.GetKind().(type) {
 	case *StringMatcher_Regex:
 		pattern := anchoredRegex(kind.Regex)

--- a/api/v1/identity_test.go
+++ b/api/v1/identity_test.go
@@ -166,6 +166,19 @@ func TestVerifyIdentity(t *testing.T) {
 				SourceRepositoryUri: "https://github.com/myorg/repo",
 			},
 		}},
+		{"sigstore-source-repo-from-context-valid", false, &Identity{
+			Sigstore: &IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{FromContext: "source_repo"},
+			},
+		}},
+		{"sigstore-from-context-with-kind-invalid", true, &Identity{
+			Sigstore: &IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{
+					FromContext: "source_repo",
+					Kind:        &StringMatcher_Exact{Exact: "https://github.com/myorg/repo"},
+				},
+			},
+		}},
 		{"key-id-match-valid", false, &Identity{
 			Key: &IdentityKey{
 				IdMatch: &StringMatcher{

--- a/api/v1/matcher.pb.go
+++ b/api/v1/matcher.pb.go
@@ -115,7 +115,7 @@ type Matcher_String_ struct {
 func (*Matcher_String_) isMatcher_Kind() {}
 
 // StringMatcher is the concrete matcher for string-valued fields.
-// Exactly one of the `kind` variants must be set.
+// Exactly one of the `kind` variants must be set, unless from_context is used.
 type StringMatcher struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -126,8 +126,12 @@ type StringMatcher struct {
 	//	*StringMatcher_Glob
 	Kind            isStringMatcher_Kind `protobuf_oneof:"kind"`
 	CaseInsensitive bool                 `protobuf:"varint,5,opt,name=case_insensitive,json=caseInsensitive,proto3" json:"case_insensitive,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// from_context names a value the matching caller (e.g. ampel) resolves into
+	// this matcher as an exact match before use. Mutually exclusive with a
+	// `kind`. If it reaches matching unresolved, the match fails closed.
+	FromContext   string `protobuf:"bytes,6,opt,name=from_context,json=fromContext,proto3" json:"from_context,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StringMatcher) Reset() {
@@ -210,6 +214,13 @@ func (x *StringMatcher) GetCaseInsensitive() bool {
 	return false
 }
 
+func (x *StringMatcher) GetFromContext() string {
+	if x != nil {
+		return x.FromContext
+	}
+	return ""
+}
+
 type isStringMatcher_Kind interface {
 	isStringMatcher_Kind()
 }
@@ -246,13 +257,14 @@ const file_carabiner_signer_v1_matcher_proto_rawDesc = "" +
 	"\aMatcher\x12\x14\n" +
 	"\x05field\x18\x01 \x01(\tR\x05field\x12<\n" +
 	"\x06string\x18\x02 \x01(\v2\".carabiner.signer.v1.StringMatcherH\x00R\x06stringB\x06\n" +
-	"\x04kind\"\xa2\x01\n" +
+	"\x04kind\"\xc5\x01\n" +
 	"\rStringMatcher\x12\x16\n" +
 	"\x05exact\x18\x01 \x01(\tH\x00R\x05exact\x12\x16\n" +
 	"\x05regex\x18\x02 \x01(\tH\x00R\x05regex\x12\x18\n" +
 	"\x06prefix\x18\x03 \x01(\tH\x00R\x06prefix\x12\x14\n" +
 	"\x04glob\x18\x04 \x01(\tH\x00R\x04glob\x12)\n" +
-	"\x10case_insensitive\x18\x05 \x01(\bR\x0fcaseInsensitiveB\x06\n" +
+	"\x10case_insensitive\x18\x05 \x01(\bR\x0fcaseInsensitive\x12!\n" +
+	"\ffrom_context\x18\x06 \x01(\tR\vfromContextB\x06\n" +
 	"\x04kindB\xbd\x01\n" +
 	"\x17com.carabiner.signer.v1B\fMatcherProtoP\x01Z&github.com/carabiner-dev/signer/api/v1\xa2\x02\x03CSX\xaa\x02\x13Carabiner.Signer.V1\xca\x02\x13Carabiner\\Signer\\V1\xe2\x02\x1fCarabiner\\Signer\\V1\\GPBMetadata\xea\x02\x15Carabiner::Signer::V1b\x06proto3"
 

--- a/api/v1/verification.go
+++ b/api/v1/verification.go
@@ -408,6 +408,12 @@ func matchString(m *StringMatcher, value string) bool {
 	if m == nil {
 		return true
 	}
+	// An unresolved from_context binding must be filled in by the caller (e.g.
+	// ampel resolves it from the verification context) before matching. If it
+	// reaches here unresolved, fail closed rather than silently ignoring it.
+	if m.GetFromContext() != "" {
+		return false
+	}
 	switch kind := m.GetKind().(type) {
 	case *StringMatcher_Exact:
 		if m.GetCaseInsensitive() {

--- a/api/v1/verification_test.go
+++ b/api/v1/verification_test.go
@@ -306,6 +306,13 @@ func TestMatchesSigstoreIdentityConvenienceMatchers(t *testing.T) {
 			false,
 		},
 		{
+			"source-repo-from-context-unresolved-fails-closed",
+			&IdentitySigstore{
+				SourceRepositoryUriMatch: &StringMatcher{FromContext: "source_repo"},
+			},
+			false,
+		},
+		{
 			"source-repo-match-combined-with-issuer-and",
 			&IdentitySigstore{
 				IssuerMatch: &StringMatcher{

--- a/proto/carabiner/signer/v1/matcher.proto
+++ b/proto/carabiner/signer/v1/matcher.proto
@@ -36,7 +36,7 @@ message Matcher {
 }
 
 // StringMatcher is the concrete matcher for string-valued fields.
-// Exactly one of the `kind` variants must be set.
+// Exactly one of the `kind` variants must be set, unless from_context is used.
 message StringMatcher {
     oneof kind {
         string exact  = 1;
@@ -45,4 +45,9 @@ message StringMatcher {
         string glob   = 4;  // shell-style glob (*, ?, [...])
     }
     bool case_insensitive = 5;
+
+    // from_context names a value the matching caller (e.g. ampel) resolves into
+    // this matcher as an exact match before use. Mutually exclusive with a
+    // `kind`. If it reaches matching unresolved, the match fails closed.
+    string from_context = 6;
 }


### PR DESCRIPTION
Follow-up to the source-repository matcher (#121). Lets a policy bind a matcher value to a
runtime context value that the consumer resolves, instead of a literal — so a published
policy can keep the signer identity baked in while the verifier supplies one value (their
source repo) at verify time.

- New `from_context` field on `StringMatcher` (proto field 6, outside the `kind` oneof) —
  names a context value the matching caller resolves into the matcher as an exact match.
- `matchString` fails closed if a `from_context` binding reaches matching unresolved.
- `validateStringMatcher` accepts `from_context` alone, rejects it combined with a `kind`.
- Signer never resolves it (no context concept here) — same split as `IdentityRef`: carried
  + validated here, the consumer does the resolving. 
  
Why: the one-command `ampel verify` path matches only issuer + SAN, so it can't bind the
origin repo the way the cosign path does — weaker by exactly that gap (TomHennen/wrangle#321).
#121 added the matcher; this lets the verifier supply the repo without baking it into every
published policy.

Ampel will do the resolving itself. PR incoming.