### PR TITLE
GCP STS provider

### DIFF
--- a/sts/README.md
+++ b/sts/README.md
@@ -1,0 +1,20 @@
+# Security Token Services
+
+This directory contains different drivers to obtain short lived tokens from
+STS providers. These are meant to be exchanged with Sigstore's Fulcio when
+obtaining a signing certificate. This readme is here mainly to answer the
+following question:
+
+__SHOULD I ADD PROVIDERS HERE?__
+
+Short answer: It depends 🙃
+
+## Where should I commit my new STS provider?
+
+We are trying to keep the signer dependency list as short as we can. So if you
+write an STS provider:
+
+- If it adds very few dependencies (note "very" is __VERY__ few and lighweight), feel free to add it here.
+- It it has a heaver dependency tree, add it to [carabiner-dev/signer-extras](https://github.com/carabiner-dev/signer-extras/).
+
+Thanks!

--- a/sts/providers/gcp/gcp.go
+++ b/sts/providers/gcp/gcp.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcp implements an ambient STS provider that reads an OIDC identity
+// token for the current service account from the Google Cloud metadata
+// server. It works on any Google Cloud compute surface that exposes the
+// metadata server (Cloud Run, GCE, GKE, Cloud Functions).
+//
+// When not running on Google Cloud the provider reports no token (nil, nil)
+// so the ambient credential flow falls through to the other providers. It is
+// deliberately dependency-light (standard library + oauthflow only), matching
+// the github and gitlab providers, so it belongs in signer itself rather than
+// signer-extras.
+package gcp
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+)
+
+const (
+	// defaultMetadataHost is the Google Cloud metadata server hostname.
+	defaultMetadataHost = "metadata.google.internal"
+
+	// metadataHostEnv mirrors the variable honoured by Google's own client
+	// libraries; when set it overrides the metadata host. It is also how tests
+	// point the provider at an httptest server.
+	metadataHostEnv = "GCE_METADATA_HOST"
+
+	// metadataFlavorHeader / metadataFlavorValue identify a genuine Google
+	// metadata server. The request must send it and the server echoes it back;
+	// we require it on the response to confirm we are really talking to the
+	// metadata server and not some proxy that happened to resolve
+	// metadata.google.internal.
+	metadataFlavorHeader = "Metadata-Flavor"
+	metadataFlavorValue  = "Google"
+
+	// identityPath mints an OIDC identity token for the default service
+	// account.
+	identityPath = "/computeMetadata/v1/instance/service-accounts/default/identity"
+
+	// defaultTimeout bounds the metadata request. Off Google Cloud the dial
+	// usually fails fast, but this cap keeps a slow or hanging lookup from
+	// stalling the ambient probe that runs on every signing.
+	defaultTimeout = 2 * time.Second
+)
+
+// Metadata is an STS provider backed by the Google Cloud metadata server. The
+// zero value is ready to use as an ambient provider; the exported fields exist
+// so tests can redirect it and are not needed in production.
+type Metadata struct {
+	// Host overrides the metadata server host. Defaults to $GCE_METADATA_HOST,
+	// then metadata.google.internal. May include a scheme (used by tests).
+	Host string
+	// Client overrides the HTTP client. Defaults to a client with Timeout.
+	Client *http.Client
+	// Timeout is used when Client is nil. Defaults to defaultTimeout.
+	Timeout time.Duration
+}
+
+// Provide returns an OIDC identity token for the current service account with
+// the given audience, or (nil, nil) when not running on Google Cloud.
+func (m *Metadata) Provide(ctx context.Context, audience string) (*oauthflow.OIDCIDToken, error) {
+	audience = strings.TrimSpace(audience)
+	if audience == "" {
+		return nil, fmt.Errorf("audience string must not be empty")
+	}
+	if strings.ContainsAny(audience, " \t\n\r&?#") {
+		return nil, fmt.Errorf("audience string contains invalid characters")
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s%s?audience=%s&format=full", m.baseURL(), identityPath, url.QueryEscape(audience),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(metadataFlavorHeader, metadataFlavorValue)
+
+	resp, err := m.client().Do(req)
+	if err != nil {
+		// A transport error means the metadata server is unreachable, i.e. we
+		// are not on Google Cloud. Report no token so the ambient flow tries
+		// the next provider rather than failing the whole signing.
+		return nil, nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	// Confirm this really is the Google metadata server and not something else
+	// that answered the metadata hostname.
+	if resp.Header.Get(metadataFlavorHeader) != metadataFlavorValue {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"metadata server returned status %d requesting identity token", resp.StatusCode,
+		)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading identity token from metadata server: %w", err)
+	}
+	raw := strings.TrimSpace(string(body))
+	if raw == "" {
+		return nil, fmt.Errorf("metadata server returned an empty identity token")
+	}
+
+	subject, err := subjectFromJWT(raw)
+	if err != nil {
+		return nil, fmt.Errorf("extracting subject from identity token: %w", err)
+	}
+
+	return &oauthflow.OIDCIDToken{RawString: raw, Subject: subject}, nil
+}
+
+// baseURL returns the scheme+host of the metadata server. The metadata server
+// speaks plain HTTP; a Host that already carries a scheme (as tests supply) is
+// used verbatim.
+func (m *Metadata) baseURL() string {
+	h := m.host()
+	if strings.HasPrefix(h, "http://") || strings.HasPrefix(h, "https://") {
+		return strings.TrimSuffix(h, "/")
+	}
+	return "http://" + h
+}
+
+func (m *Metadata) host() string {
+	if m.Host != "" {
+		return m.Host
+	}
+	if env := os.Getenv(metadataHostEnv); env != "" {
+		return env
+	}
+	return defaultMetadataHost
+}
+
+func (m *Metadata) client() *http.Client {
+	if m.Client != nil {
+		return m.Client
+	}
+	timeout := m.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+	return &http.Client{Timeout: timeout}
+}
+
+// subjectFromJWT extracts the subject claim from an unverified JWT (Fulcio
+// verifies the token when issuing the certificate). Mirrors the gitlab
+// provider's handling.
+func subjectFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed JWT: expected 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decoding JWT payload: %w", err)
+	}
+	return oauthflow.SubjectFromUnverifiedToken(payload)
+}

--- a/sts/providers/gcp/gcp_test.go
+++ b/sts/providers/gcp/gcp_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeJWT builds an unsigned three-part JWT whose payload carries the given
+// subject, enough for subjectFromJWT to parse.
+func fakeJWT(t *testing.T, subject string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"` + subject + `","aud":"sigstore"}`))
+	sig := base64.RawURLEncoding.EncodeToString([]byte("signature"))
+	return header + "." + payload + "." + sig
+}
+
+func TestProvide(t *testing.T) {
+	t.Parallel()
+	const subject = "miniprow@example.iam.gserviceaccount.com"
+	token := fakeJWT(t, subject)
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/computeMetadata/v1/instance/service-accounts/default/identity", r.URL.Path)
+			assert.Equal(t, "sigstore", r.URL.Query().Get("audience"))
+			assert.Equal(t, "full", r.URL.Query().Get("format"))
+			assert.Equal(t, metadataFlavorValue, r.Header.Get(metadataFlavorHeader))
+			w.Header().Set(metadataFlavorHeader, metadataFlavorValue)
+			_, _ = w.Write([]byte(token + "\n")) //nolint:errcheck // test handler
+		}))
+		defer srv.Close()
+
+		m := &Metadata{Host: srv.URL, Client: srv.Client()}
+		got, err := m.Provide(context.Background(), "sigstore")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, token, got.RawString)
+		assert.Equal(t, subject, got.Subject)
+	})
+
+	t.Run("not on gcp - transport error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(metadataFlavorHeader, metadataFlavorValue)
+			_, _ = w.Write([]byte(token)) //nolint:errcheck // test handler
+		}))
+		url := srv.URL
+		srv.Close() // now unreachable: stands in for "not on Google Cloud"
+
+		m := &Metadata{Host: url, Client: srv.Client()}
+		got, err := m.Provide(context.Background(), "sigstore")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("missing metadata-flavor header is not the real server", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// No Metadata-Flavor response header.
+			_, _ = w.Write([]byte(token)) //nolint:errcheck // test handler
+		}))
+		defer srv.Close()
+
+		m := &Metadata{Host: srv.URL, Client: srv.Client()}
+		got, err := m.Provide(context.Background(), "sigstore")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("on gcp but non-200 is an error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(metadataFlavorHeader, metadataFlavorValue)
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		m := &Metadata{Host: srv.URL, Client: srv.Client()}
+		got, err := m.Provide(context.Background(), "sigstore")
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("empty audience is rejected", func(t *testing.T) {
+		t.Parallel()
+		m := &Metadata{}
+		_, err := m.Provide(context.Background(), "  ")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid audience is rejected", func(t *testing.T) {
+		t.Parallel()
+		m := &Metadata{}
+		_, err := m.Provide(context.Background(), "bad audience?x=1")
+		require.Error(t, err)
+	})
+}

--- a/sts/sts.go
+++ b/sts/sts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sigstore/sigstore/pkg/oauthflow"
 
+	"github.com/carabiner-dev/signer/sts/providers/gcp"
 	"github.com/carabiner-dev/signer/sts/providers/github"
 	"github.com/carabiner-dev/signer/sts/providers/gitlab"
 )
@@ -17,14 +18,18 @@ import (
 var (
 	_ Provider = &github.Actions{}
 	_ Provider = &gitlab.CI{}
+	_ Provider = &gcp.Metadata{}
 )
 
-// These are the two default STS providers, the signer project has additional
+// These are the default STS providers, the signer project has additional
 // providers in https://github.com/carabiner-dev/signer-extras which have a
-// heavier dependency footprint.
+// heavier dependency footprint. gcp reads the service-account identity token
+// from the Google Cloud metadata server and, like the others, reports no token
+// when its environment is absent.
 var DefaultProviders = map[string]Provider{
 	"gitlab":  &gitlab.CI{},
 	"actions": &github.Actions{},
+	"gcp":     &gcp.Metadata{},
 }
 
 var mtx sync.Mutex


### PR DESCRIPTION
This pull request adds support for Google Cloud Platform (GCP) as an ambient Security Token Service (STS) provider. The new provider enables the system to obtain OIDC identity tokens from the GCP metadata server, allowing seamless integration on any Google Cloud compute environment. The implementation is kept lightweight to avoid introducing heavy dependencies. The pull request also includes a comprehensive test suite and documentation for the new provider.

**GCP STS Provider Implementation:**

- Added a new `gcp` STS provider (`sts/providers/gcp/gcp.go`) that retrieves OIDC identity tokens from the GCP metadata server. The provider is dependency-light and only uses the standard library and `oauthflow`. It returns no token when not running on GCP, allowing fallback to other providers.
- Added a test suite for the GCP provider (`sts/providers/gcp/gcp_test.go`) that covers successful token retrieval, error cases, and edge conditions.

**Integration and Documentation:**

- Registered the GCP provider in the default providers list in `sts/sts.go`, ensuring it is available as part of the ambient credential flow. [[1]](diffhunk://#diff-7950980d305eb928e9d271d69bf2b8efb940805f57ab3b4ff9abdb206f51fe65R12) [[2]](diffhunk://#diff-7950980d305eb928e9d271d69bf2b8efb940805f57ab3b4ff9abdb206f51fe65R21-R32)
- Added a `README.md` to the `sts/` directory with guidelines for contributing new providers and clarifying when to add providers to the main repo versus `signer-extras`.