### PR TITLE
Add CertifiedKey functions

### DIFF
--- a/certified_key_test.go
+++ b/certified_key_test.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/signer/bundle/bundlefakes"
+)
+
+// TestCertifiedKeyRejectsNonSigstoreCredentials verifies the sigstore backend
+// requirement: a non-sigstore credential provider is rejected before any flow
+// runs. The hermetic positive tests for the material itself live in the
+// sigstore package (CredentialProvider.CertifiedKey).
+func TestCertifiedKeyRejectsNonSigstoreCredentials(t *testing.T) {
+	t.Parallel()
+	s := NewSigner()
+	s.Credentials = &bundlefakes.FakeCredentialProvider{}
+
+	leaf, chain, key, err := s.CertifiedKey(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "requires the sigstore backend")
+	require.Nil(t, leaf)
+	require.Nil(t, chain)
+	require.Nil(t, key)
+}

--- a/signer.go
+++ b/signer.go
@@ -4,6 +4,9 @@
 package signer
 
 import (
+	"context"
+	"crypto"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -306,6 +309,31 @@ func (s *Signer) SignEnvelope(envelope *sdsse.Envelope, funcs ...options.SignOpt
 		return fmt.Errorf("signing envelope: %w", err)
 	}
 	return nil
+}
+
+// CertifiedKey runs the keyless (Fulcio) flow with a fresh key and returns the
+// leaf certificate, its intermediate chain, and the private key, suitable for
+// building a detached CMS/PKCS7 signature. It uses the same ambient identity
+// as the signer's sigstore backend: the OIDC token is obtained through the
+// existing credential/Prepare flow, honoring an injected Options.Token and DisableSTS.
+//
+// It requires the sigstore backend. When Signer.Credentials is already a
+// *sigstore.CredentialProvider it is reused, otherwise one is built from
+// Signer.Options. A non-sigstore Credentials value is rejected.
+func (s *Signer) CertifiedKey(ctx context.Context) (leaf *x509.Certificate, chain []*x509.Certificate, key crypto.Signer, err error) {
+	var cp *sigstore.CredentialProvider
+	switch creds := s.Credentials.(type) {
+	case nil:
+		if verr := s.Options.Validate(); verr != nil {
+			return nil, nil, nil, fmt.Errorf("validating options: %w", verr)
+		}
+		cp = s.Options.BuildSigstoreCredentials()
+	case *sigstore.CredentialProvider:
+		cp = creds
+	default:
+		return nil, nil, nil, fmt.Errorf("CertifiedKey requires the sigstore backend; Signer.Credentials is %T", s.Credentials)
+	}
+	return cp.CertifiedKey(ctx)
 }
 
 // Close releases resources held by the Signer's credentials. It's a

--- a/sigstore/certified_key_test.go
+++ b/sigstore/certified_key_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCA issues short-lived certificates over a caller-provided public key,
+// standing in for the Fulcio flow so CertifiedKey can be exercised hermetically.
+type fakeCA struct {
+	rootCert  *x509.Certificate
+	interKey  *ecdsa.PrivateKey
+	interCert *x509.Certificate
+}
+
+func newFakeCA(t *testing.T) *fakeCA {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "fake-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	rootCert := signCert(t, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+
+	interKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	interTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "fake-intermediate"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	interCert := signCert(t, interTmpl, rootCert, &interKey.PublicKey, rootKey)
+
+	return &fakeCA{rootCert: rootCert, interKey: interKey, interCert: interCert}
+}
+
+// issueLeaf signs a code-signing leaf over pub using the intermediate key.
+func (ca *fakeCA) issueLeaf(t *testing.T, pub crypto.PublicKey) *x509.Certificate {
+	t.Helper()
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "signer@example.com"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(10 * time.Minute),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+	}
+	return signCert(t, leafTmpl, ca.interCert, pub, ca.interKey)
+}
+
+func signCert(t *testing.T, tmpl, parent *x509.Certificate, pub crypto.PublicKey, signer crypto.Signer) *x509.Certificate {
+	t.Helper()
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pub, signer)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// fakeChainProvider implements sign.CertificateProvider and
+// sign.CertificateChainProvider, returning [leaf, intermediate].
+type fakeChainProvider struct {
+	t  *testing.T
+	ca *fakeCA
+}
+
+func (f *fakeChainProvider) GetCertificate(_ context.Context, kp sign.Keypair, _ *sign.CertificateProviderOptions) ([]byte, error) {
+	return f.ca.issueLeaf(f.t, kp.GetPublicKey()).Raw, nil
+}
+
+func (f *fakeChainProvider) GetCertificateChain(_ context.Context, kp sign.Keypair, _ *sign.CertificateProviderOptions) ([][]byte, error) {
+	leaf := f.ca.issueLeaf(f.t, kp.GetPublicKey())
+	return [][]byte{leaf.Raw, f.ca.interCert.Raw}, nil
+}
+
+// fakeLeafProvider implements only sign.CertificateProvider (like the real
+// Fulcio provider), returning just the leaf.
+type fakeLeafProvider struct {
+	t  *testing.T
+	ca *fakeCA
+}
+
+func (f *fakeLeafProvider) GetCertificate(_ context.Context, kp sign.Keypair, _ *sign.CertificateProviderOptions) ([]byte, error) {
+	return f.ca.issueLeaf(f.t, kp.GetPublicKey()).Raw, nil
+}
+
+// preparedProvider builds a CredentialProvider that is already prepared so
+// CertifiedKey skips the network-bound Prepare and uses the injected cp.
+func preparedProvider(cp sign.CertificateProvider) *CredentialProvider {
+	return &CredentialProvider{
+		Instance: &Instance{},
+		Token:    &oauthflow.OIDCIDToken{RawString: "fake-token"},
+		cp:       cp,
+		prepared: true,
+	}
+}
+
+func TestCertifiedKeyWithChainProvider(t *testing.T) {
+	t.Parallel()
+	ca := newFakeCA(t)
+	p := preparedProvider(&fakeChainProvider{t: t, ca: ca})
+
+	leaf, chain, key, err := p.CertifiedKey(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, leaf)
+	require.NotNil(t, key)
+
+	// The returned certificate must bind to the returned private key.
+	pub, ok := key.Public().(*ecdsa.PublicKey)
+	require.True(t, ok)
+	require.True(t, pub.Equal(leaf.PublicKey))
+
+	// The chain carries the intermediate (root excluded) and the leaf verifies
+	// against it.
+	require.Len(t, chain, 1)
+	require.Equal(t, ca.interCert.Raw, chain[0].Raw)
+	require.NoError(t, leaf.CheckSignatureFrom(chain[0]))
+}
+
+func TestCertifiedKeyLeafOnlyProvider(t *testing.T) {
+	t.Parallel()
+	ca := newFakeCA(t)
+	p := preparedProvider(&fakeLeafProvider{t: t, ca: ca})
+
+	leaf, chain, key, err := p.CertifiedKey(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, leaf)
+	require.NotNil(t, key)
+
+	// With no chain provider and no trusted root, the intermediate chain is
+	// empty but the leaf still binds to the returned key.
+	require.Empty(t, chain)
+	pub, ok := key.Public().(*ecdsa.PublicKey)
+	require.True(t, ok)
+	require.True(t, pub.Equal(leaf.PublicKey))
+}

--- a/sigstore/credential_provider.go
+++ b/sigstore/credential_provider.go
@@ -4,7 +4,11 @@
 package sigstore
 
 import (
+	"bytes"
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"errors"
@@ -39,9 +43,10 @@ type CredentialProvider struct {
 	// that it is parsed/validated the same way as a freshly issued one.
 	Token *oauthflow.OIDCIDToken
 
-	keypair  *sign.EphemeralKeypair
-	cp       sign.CertificateProvider
-	prepared bool
+	keypair     *sign.EphemeralKeypair
+	cp          sign.CertificateProvider
+	trustedRoot *root.TrustedRoot
+	prepared    bool
 }
 
 // NewCredentialProvider creates a sigstore CredentialProvider for the given Instance.
@@ -67,9 +72,13 @@ func (p *CredentialProvider) Prepare(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating TUF client: %w", err)
 	}
-	if _, err := root.GetTrustedRoot(tufClient); err != nil {
+	trustedRoot, err := root.GetTrustedRoot(tufClient)
+	if err != nil {
 		return fmt.Errorf("fetching TUF root: %w", err)
 	}
+	// Keep the trusted root so CertifiedKey can reconstruct the Fulcio
+	// intermediate chain (sigstore-go's Fulcio provider returns only the leaf).
+	p.trustedRoot = trustedRoot
 
 	// Generate the ephemeral keypair that will be bound to the Fulcio cert.
 	kp, err := sign.NewEphemeralKeypair(nil)
@@ -130,6 +139,138 @@ func (p *CredentialProvider) CertificateProvider() (sign.CertificateProvider, *s
 // time from the sigstore TUF root, so no intermediates are embedded in the
 // bundle's VerificationMaterial.
 func (p *CredentialProvider) Intermediates() []*x509.Certificate { return nil }
+
+// CertifiedKey runs the keyless (Fulcio) flow with a freshly generated key and
+// returns the leaf certificate with its intermediate chain (leaf-adjacent first,
+// root excluded), and the private key. The material is suitable for building a
+// detached CMS/PKCS7 signature. We built this to emulate the gitsign signer but
+// it can be used to sign anything with the same ambient identity the sigstore
+// bundle backend signs with.
+//
+// Unlike the bundle path, the returned key is available to the caller as a
+// crypto.Signer,. this function generates its own key and drives the Fulcio
+// certificate request with it but ( as opposed to sigstore-go's that hides its
+// its key in EphemeralKeypair), the issued certificate binds to a key the caller
+// gets to keep.
+//
+// The ambient OIDC token and Fulcio provider are obtained through Prepare, so an
+// injected Token / DisableSTS is honored exactly like the signing path.
+func (p *CredentialProvider) CertifiedKey(ctx context.Context) (
+	leaf *x509.Certificate, chain []*x509.Certificate, key crypto.Signer, err error,
+) {
+	if err := p.Prepare(ctx); err != nil {
+		return nil, nil, nil, fmt.Errorf("preparing credentials: %w", err)
+	}
+
+	// Generate our own key so we can hand the crypto.Signer back to the caller.
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generating signing key: %w", err)
+	}
+	kp, err := NewSignerKeypair(priv, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("building keypair: %w", err)
+	}
+
+	cp, opts := p.CertificateProvider()
+	if cp == nil {
+		return nil, nil, nil, errors.New("no certificate provider available after Prepare")
+	}
+	// Bypass the validity-window cache: it is keyed only by time, not by
+	// keypair, so it may hold a certificate bound to the bundle path's ephemeral
+	// key. We need one freshly bound to the key we just generated.
+	if cc, ok := cp.(*cachingCertProvider); ok {
+		cp = cc.inner
+	}
+
+	// When the provider can return a full chain (leaf + intermediates), use it.
+	// The real Fulcio provider only returns the leaf, so fall back to
+	// reconstructing the intermediates from the sigstore trusted root.
+	if ccp, ok := cp.(sign.CertificateChainProvider); ok {
+		chainDER, cerr := ccp.GetCertificateChain(ctx, kp, opts)
+		if cerr != nil {
+			return nil, nil, nil, fmt.Errorf("requesting certificate chain: %w", cerr)
+		}
+		leaf, chain, err = parseLeafAndChain(chainDER)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		return leaf, chain, priv, nil
+	}
+
+	leafDER, cerr := cp.GetCertificate(ctx, kp, opts)
+	if cerr != nil {
+		return nil, nil, nil, fmt.Errorf("requesting certificate: %w", cerr)
+	}
+	leaf, err = x509.ParseCertificate(leafDER)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parsing leaf certificate: %w", err)
+	}
+	return leaf, p.fulcioIntermediates(leaf), priv, nil
+}
+
+// fulcioIntermediates reconstructs the intermediate chain for a Fulcio-issued
+// leaf from the sigstore trusted root. sigstore-go's Fulcio provider returns
+// only the leaf, so the intermediates — which a detached CMS signature needs to
+// chain to the Fulcio root — come from the trust root fetched during Prepare.
+// Returns nil when no matching authority is found: the leaf alone is still
+// usable and the caller can supply intermediates from its own trust root.
+func (p *CredentialProvider) fulcioIntermediates(leaf *x509.Certificate) []*x509.Certificate {
+	if p.trustedRoot == nil || leaf == nil {
+		return nil
+	}
+	for _, ca := range p.trustedRoot.FulcioCertificateAuthorities() {
+		chains, err := ca.Verify(leaf, leaf.NotBefore)
+		if err != nil || len(chains) == 0 {
+			continue
+		}
+		// Each chain is [leaf, intermediate(s)..., root]; drop leaf and root.
+		chain := chains[0]
+		if len(chain) <= 2 {
+			return nil
+		}
+		intermediates := chain[1 : len(chain)-1]
+		out := make([]*x509.Certificate, len(intermediates))
+		copy(out, intermediates)
+		return out
+	}
+	return nil
+}
+
+// parseLeafAndChain parses a DER chain (leaf first) into the leaf certificate
+// and its intermediates, dropping a trailing self-signed root if the provider
+// included one (CMS callers supply the trust anchor out of band).
+func parseLeafAndChain(chainDER [][]byte) (leaf *x509.Certificate, chain []*x509.Certificate, err error) {
+	if len(chainDER) == 0 {
+		return nil, nil, errors.New("certificate provider returned an empty chain")
+	}
+	certs := make([]*x509.Certificate, 0, len(chainDER))
+	for i, der := range chainDER {
+		c, perr := x509.ParseCertificate(der)
+		if perr != nil {
+			return nil, nil, fmt.Errorf("parsing certificate %d in chain: %w", i, perr)
+		}
+		certs = append(certs, c)
+	}
+
+	leaf = certs[0]
+	intermediates := certs[1:]
+	if n := len(intermediates); n > 0 && isSelfSigned(intermediates[n-1]) {
+		intermediates = intermediates[:n-1]
+	}
+	if len(intermediates) == 0 {
+		return leaf, nil, nil
+	}
+	out := make([]*x509.Certificate, len(intermediates))
+	copy(out, intermediates)
+	return leaf, out, nil
+}
+
+// isSelfSigned reports whether a certificate's issuer equals its subject, the
+// hallmark of a trust-anchor root.
+func isSelfSigned(cert *x509.Certificate) bool {
+	return bytes.Equal(cert.RawIssuer, cert.RawSubject)
+}
 
 // runAmbientSTS iterates over the configured STS providers until it gets a token
 func (p *CredentialProvider) runAmbientSTS(ctx context.Context) error {

--- a/sigstore/keypair.go
+++ b/sigstore/keypair.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+// SignerKeypairOptions configures a SignerKeypair.
+type SignerKeypairOptions struct {
+	// Hint is the optional public-key fingerprint sent to Fulcio. When empty a
+	// base64-encoded SHA-256 hash of the DER-encoded public key is used, exactly
+	// like sigstore-go's EphemeralKeypair.
+	Hint []byte
+
+	// Algorithm selects the signing algorithm. Defaults to ECDSA P-256 SHA-256.
+	Algorithm protocommon.PublicKeyDetails
+}
+
+// SignerKeypair adapts a caller-provided crypto.Signer to the sigstore-go
+// sign.Keypair interface. Unlike sign.EphemeralKeypair — which generates its
+// private key internally and never exposes it — SignerKeypair signs with a key
+// the caller owns and keeps. That is what lets CertifiedKey hand the private key
+// back so callers can build a detached CMS/PKCS7 signature (e.g. a signed git
+// tag) with the same keyless identity the signer uses.
+type SignerKeypair struct {
+	options    SignerKeypairOptions
+	signer     crypto.Signer
+	algDetails signature.AlgorithmDetails
+}
+
+// Assert that SignerKeypair implements the sigstore-go keypair interface.
+var _ sign.Keypair = (*SignerKeypair)(nil)
+
+// NewSignerKeypair wraps signer in a sign.Keypair. When opts is nil the keypair
+// defaults to ECDSA P-256 SHA-256 with a SHA-256 public-key hint. The logic
+// mirrors sign.NewEphemeralKeypair, but signs with the provided key instead of a
+// freshly generated one.
+func NewSignerKeypair(signer crypto.Signer, opts *SignerKeypairOptions) (*SignerKeypair, error) {
+	if signer == nil {
+		return nil, errors.New("crypto.Signer must not be nil")
+	}
+
+	options := SignerKeypairOptions{}
+	if opts != nil {
+		options = *opts
+	}
+
+	// Default signing algorithm is ECDSA P-256 SHA-256.
+	if options.Algorithm == protocommon.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED {
+		options.Algorithm = protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256
+	}
+	algDetails, err := signature.GetAlgorithmDetails(options.Algorithm)
+	if err != nil {
+		return nil, fmt.Errorf("resolving algorithm details: %w", err)
+	}
+
+	if options.Hint == nil {
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(signer.Public())
+		if err != nil {
+			return nil, fmt.Errorf("marshaling public key for hint: %w", err)
+		}
+		hashedBytes := sha256.Sum256(pubKeyBytes)
+		options.Hint = []byte(base64.StdEncoding.EncodeToString(hashedBytes[:]))
+	}
+
+	return &SignerKeypair{
+		options:    options,
+		signer:     signer,
+		algDetails: algDetails,
+	}, nil
+}
+
+// GetHashAlgorithm returns the hash algorithm used to compute the digest to sign.
+func (k *SignerKeypair) GetHashAlgorithm() protocommon.HashAlgorithm {
+	return k.algDetails.GetProtoHashType()
+}
+
+// GetSigningAlgorithm returns the signing algorithm of the key.
+func (k *SignerKeypair) GetSigningAlgorithm() protocommon.PublicKeyDetails {
+	return k.algDetails.GetSignatureAlgorithm()
+}
+
+// GetHint returns the fingerprint of the public key.
+func (k *SignerKeypair) GetHint() []byte {
+	return k.options.Hint
+}
+
+// GetKeyAlgorithm returns the top-level key algorithm, used as part of requests
+// to Fulcio.
+func (k *SignerKeypair) GetKeyAlgorithm() string {
+	switch k.algDetails.GetKeyType() {
+	case signature.ECDSA:
+		return "ECDSA"
+	case signature.RSA:
+		return "RSA"
+	case signature.ED25519:
+		return "ED25519"
+	default:
+		return ""
+	}
+}
+
+// GetPublicKey returns the public key.
+func (k *SignerKeypair) GetPublicKey() crypto.PublicKey {
+	return k.signer.Public()
+}
+
+// GetPublicKeyPem returns the public key in PEM format.
+func (k *SignerKeypair) GetPublicKeyPem() (string, error) {
+	pubKeyBytes, err := cryptoutils.MarshalPublicKeyToPEM(k.signer.Public())
+	if err != nil {
+		return "", fmt.Errorf("marshaling public key to PEM: %w", err)
+	}
+	return string(pubKeyBytes), nil
+}
+
+// SignData returns the signature and the data that was signed (a digest, except
+// for pure Ed25519). It mirrors sign.EphemeralKeypair.SignData over the provided
+// key.
+func (k *SignerKeypair) SignData(_ context.Context, data []byte) (sig, digest []byte, err error) {
+	hf := k.algDetails.GetHashType()
+	dataToSign := data
+	// RSA, ECDSA, and Ed25519ph sign a digest, while pure Ed25519 hashes the
+	// data itself during signing.
+	if hf != crypto.Hash(0) {
+		hasher := hf.New()
+		hasher.Write(data)
+		dataToSign = hasher.Sum(nil)
+	}
+	signed, err := k.signer.Sign(rand.Reader, dataToSign, hf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("signing data: %w", err)
+	}
+	return signed, dataToSign, nil
+}

--- a/sigstore/keypair_test.go
+++ b/sigstore/keypair_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"testing"
+
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSignerKeypairNilSigner(t *testing.T) {
+	t.Parallel()
+	kp, err := NewSignerKeypair(nil, nil)
+	require.Error(t, err)
+	require.Nil(t, kp)
+}
+
+func TestSignerKeypairDefaults(t *testing.T) {
+	t.Parallel()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	kp, err := NewSignerKeypair(priv, nil)
+	require.NoError(t, err)
+
+	// The wrapped key must be the exact key the caller provided.
+	pub, ok := kp.GetPublicKey().(*ecdsa.PublicKey)
+	require.True(t, ok)
+	require.True(t, pub.Equal(&priv.PublicKey))
+
+	require.Equal(t, "ECDSA", kp.GetKeyAlgorithm())
+	require.Equal(t, protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256, kp.GetSigningAlgorithm())
+	require.Equal(t, protocommon.HashAlgorithm_SHA2_256, kp.GetHashAlgorithm())
+	require.NotEmpty(t, kp.GetHint())
+
+	pem, err := kp.GetPublicKeyPem()
+	require.NoError(t, err)
+	parsed, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(pem))
+	require.NoError(t, err)
+	parsedECDSA, ok := parsed.(*ecdsa.PublicKey)
+	require.True(t, ok)
+	require.True(t, parsedECDSA.Equal(&priv.PublicKey))
+}
+
+func TestSignerKeypairSignData(t *testing.T) {
+	t.Parallel()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	kp, err := NewSignerKeypair(priv, nil)
+	require.NoError(t, err)
+
+	data := []byte("proof-of-possession subject")
+	sig, digest, err := kp.SignData(t.Context(), data)
+	require.NoError(t, err)
+
+	// Digest is the SHA-256 of the data, and the signature verifies against the
+	// caller-owned key over that digest.
+	want := sha256.Sum256(data)
+	require.Equal(t, want[:], digest)
+	require.True(t, ecdsa.VerifyASN1(&priv.PublicKey, digest, sig))
+}
+
+func TestSignerKeypairCustomHint(t *testing.T) {
+	t.Parallel()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	hint := []byte("my-hint")
+	kp, err := NewSignerKeypair(priv, &SignerKeypairOptions{Hint: hint})
+	require.NoError(t, err)
+	require.Equal(t, hint, kp.GetHint())
+}


### PR DESCRIPTION
This PR adds a new CertifiedKeys function (to the sigstore backend butr surfaced too on the main signer). The idea is that callers can request an ephemeral key backed by a certificate from Fulcio so that other signing operations can leverage a key tracked in the transparency log.

The function uses the same sigstore backend so it can use the same ambien credentials and options. I also added tests