### PR TITLE
Add gcp.Provider with support for ADC and service accounts

### DIFF
--- a/sts/providers/gcp/gcp.go
+++ b/sts/providers/gcp/gcp.go
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
-// Package gcp implements an ambient STS provider that reads an OIDC identity
-// token for the current service account from the Google Cloud metadata
-// server. It works on any Google Cloud compute surface that exposes the
-// metadata server (Cloud Run, GCE, GKE, Cloud Functions).
+// Package gcp implements an STS provider that mints Google Cloud OIDC
+// identity tokens. Provider resolves a credential in application-default
+// order: an explicitly configured service-account key, then a key file named
+// by $GOOGLE_APPLICATION_CREDENTIALS, then the ambient metadata server
+// (available when running on Google Cloud. Metadata is the metadata-server
+// piece on its own.
 //
-// When not running on Google Cloud the provider reports no token (nil, nil)
+// When no credential source yields a token the provider reports (nil, nil)
 // so the ambient credential flow falls through to the other providers. It is
 // deliberately dependency-light (standard library + oauthflow only), matching
 // the github and gitlab providers, so it belongs in signer itself rather than
@@ -70,12 +72,9 @@ type Metadata struct {
 // Provide returns an OIDC identity token for the current service account with
 // the given audience, or (nil, nil) when not running on Google Cloud.
 func (m *Metadata) Provide(ctx context.Context, audience string) (*oauthflow.OIDCIDToken, error) {
-	audience = strings.TrimSpace(audience)
-	if audience == "" {
-		return nil, fmt.Errorf("audience string must not be empty")
-	}
-	if strings.ContainsAny(audience, " \t\n\r&?#") {
-		return nil, fmt.Errorf("audience string contains invalid characters")
+	audience, err := validateAudience(audience)
+	if err != nil {
+		return nil, err
 	}
 
 	endpoint := fmt.Sprintf(
@@ -154,6 +153,19 @@ func (m *Metadata) client() *http.Client {
 		timeout = defaultTimeout
 	}
 	return &http.Client{Timeout: timeout}
+}
+
+// validateAudience normalizes and validates the requested token audience.
+// Shared by the metadata and service-account flows.
+func validateAudience(audience string) (string, error) {
+	audience = strings.TrimSpace(audience)
+	if audience == "" {
+		return "", fmt.Errorf("audience string must not be empty")
+	}
+	if strings.ContainsAny(audience, " \t\n\r&?#") {
+		return "", fmt.Errorf("audience string contains invalid characters")
+	}
+	return audience, nil
 }
 
 // subjectFromJWT extracts the subject claim from an unverified JWT (Fulcio

--- a/sts/providers/gcp/provider.go
+++ b/sts/providers/gcp/provider.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+)
+
+// Provider is the Google Cloud STS provider. It resolves a credential in
+// application-default order: a service-account key configured with
+// WithServiceAccountJSON / WithServiceAccountFile, then a key file named by
+// $GOOGLE_APPLICATION_CREDENTIALS, then the ambient metadata server.
+//
+// When a service-account key fails, the provider falls back to the metadata
+// server unless WithAmbientCredentials(false) disabled it. The zero value is
+// the ambient default: no explicit key, env var honored, metadata enabled.
+type Provider struct {
+	// Metadata is the metadata-server provider used as the ambient credential
+	// source. Its exported fields exist so tests can redirect it.
+	Metadata Metadata
+
+	sa      *serviceAccount
+	ambient *bool
+}
+
+// Option configures a Provider built with New.
+type Option func(*Provider) error
+
+// New builds a Provider from the given options.
+func New(opts ...Option) (*Provider, error) {
+	p := &Provider{}
+	for _, opt := range opts {
+		if err := opt(p); err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
+// WithServiceAccountJSON configures the provider to mint identity tokens with
+// the given service-account JSON key instead of the ambient credentials.
+func WithServiceAccountJSON(data []byte) Option {
+	return func(p *Provider) error {
+		sa, err := parseServiceAccount(data)
+		if err != nil {
+			return err
+		}
+		p.sa = sa
+		return nil
+	}
+}
+
+// WithServiceAccountFile is WithServiceAccountJSON reading the key from path.
+func WithServiceAccountFile(path string) Option {
+	return func(p *Provider) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading service account key: %w", err)
+		}
+		return WithServiceAccountJSON(data)(p)
+	}
+}
+
+// WithAmbientCredentials controls whether the provider may use the metadata
+// server, both as the last credential source and as the fallback when a
+// configured service-account key fails. It defaults to enabled.
+func WithAmbientCredentials(enabled bool) Option {
+	return func(p *Provider) error {
+		p.ambient = &enabled
+		return nil
+	}
+}
+
+func (p *Provider) ambientEnabled() bool {
+	return p.ambient == nil || *p.ambient
+}
+
+// Provide returns an OIDC identity token with the given audience from the
+// first credential source that yields one, or (nil, nil) when none is
+// available and none was explicitly configured.
+func (p *Provider) Provide(ctx context.Context, audience string) (*oauthflow.OIDCIDToken, error) {
+	sa, saErr := p.credential()
+	if sa != nil {
+		token, err := sa.provide(ctx, audience)
+		if err == nil {
+			return token, nil
+		}
+		saErr = err
+	}
+
+	if !p.ambientEnabled() {
+		if saErr != nil {
+			return nil, saErr
+		}
+		return nil, errors.New("ambient credentials disabled and no service account key configured")
+	}
+
+	token, err := p.Metadata.Provide(ctx, audience)
+	if err == nil && token != nil {
+		return token, nil
+	}
+	if saErr != nil {
+		// The configured key failed and the fallback produced nothing: the
+		// key failure is the actionable error, don't swallow it.
+		return nil, fmt.Errorf("service account credential failed (no metadata server fallback): %w", saErr)
+	}
+	return token, err
+}
+
+// credential returns the service-account key to use: the explicitly
+// configured one, else one named by $GOOGLE_APPLICATION_CREDENTIALS. A nil,
+// nil return means no key is in play and the metadata server is the only
+// candidate. Env-var credentials of other ADC types (authorized_user,
+// external_account) are skipped silently: they are valid for Google's own
+// libraries but cannot mint arbitrary-audience identity tokens.
+func (p *Provider) credential() (*serviceAccount, error) {
+	if p.sa != nil {
+		return p.sa, nil
+	}
+	path := os.Getenv(credentialsEnv)
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // G703: reading the file the env var names is the ADC contract
+	if err != nil {
+		return nil, fmt.Errorf("reading %s key file: %w", credentialsEnv, err)
+	}
+	probe := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("parsing %s key file: %w", credentialsEnv, err)
+	}
+	if probe.Type != serviceAccountType {
+		return nil, nil
+	}
+	sa, err := parseServiceAccount(data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", credentialsEnv, err)
+	}
+	return sa, nil
+}

--- a/sts/providers/gcp/provider_test.go
+++ b/sts/providers/gcp/provider_test.go
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testEmail = "signer@example.iam.gserviceaccount.com"
+
+// testKey is generated once; 2048-bit keygen is slow enough to share.
+var testKey = func() *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}()
+
+// serviceAccountJSON builds a service-account key file whose token_uri points
+// at tokenURI (an httptest server in these tests).
+func serviceAccountJSON(t *testing.T, tokenURI string) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(testKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	data, err := json.Marshal(map[string]string{
+		"type":           "service_account",
+		"client_email":   testEmail,
+		"private_key_id": "key-1",
+		"private_key":    string(keyPEM),
+		"token_uri":      tokenURI,
+	})
+	require.NoError(t, err)
+	return data
+}
+
+// tokenEndpoint fakes Google's OAuth token endpoint: it verifies the
+// JWT-bearer request (including the assertion's RS256 signature and claims)
+// and answers with an id_token for the requested target_audience.
+func tokenEndpoint(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		assert.Equal(t, jwtBearerGrant, r.Form.Get("grant_type"))
+
+		parts := splitJWT(t, r.Form.Get("assertion"))
+		digest := sha256.Sum256([]byte(parts.signingInput))
+		assert.NoError(t, rsa.VerifyPKCS1v15(&testKey.PublicKey, crypto.SHA256, digest[:], parts.signature))
+		assert.Equal(t, testEmail, parts.claims["iss"])
+		assert.Equal(t, testEmail, parts.claims["sub"])
+		assert.Equal(t, "sigstore", parts.claims["target_audience"])
+
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		idToken := fakeJWT(t, testEmail)
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"id_token": idToken}))
+	}))
+}
+
+type jwtParts struct {
+	signingInput string
+	signature    []byte
+	claims       map[string]any
+}
+
+func splitJWT(t *testing.T, token string) jwtParts {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "assertion is not a three-part JWT")
+	rawSig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	rawPayload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	claims := map[string]any{}
+	require.NoError(t, json.Unmarshal(rawPayload, &claims))
+	return jwtParts{
+		signingInput: parts[0] + "." + parts[1],
+		signature:    rawSig,
+		claims:       claims,
+	}
+}
+
+// metadataServer fakes the metadata server answering with a token.
+func metadataServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(metadataFlavorHeader, metadataFlavorValue)
+		_, _ = w.Write([]byte(fakeJWT(t, "metadata-sa@example.iam.gserviceaccount.com"))) //nolint:errcheck // test handler
+	}))
+}
+
+// deadMetadata returns a Metadata pointed at a closed server, standing in for
+// "not on Google Cloud".
+func deadMetadata(t *testing.T) Metadata {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	return Metadata{Host: srv.URL}
+}
+
+// TestProviderProvide covers the credential resolution of the full Provider.
+// No t.Parallel: the subtests use t.Setenv to isolate the ADC variable.
+func TestProviderProvide(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("explicit service account", func(t *testing.T) {
+		t.Setenv(credentialsEnv, "")
+		srv := tokenEndpoint(t, http.StatusOK)
+		defer srv.Close()
+
+		p, err := New(WithServiceAccountJSON(serviceAccountJSON(t, srv.URL)))
+		require.NoError(t, err)
+		got, err := p.Provide(ctx, "sigstore")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, testEmail, got.Subject)
+	})
+
+	t.Run("service account failure falls back to metadata by default", func(t *testing.T) {
+		t.Setenv(credentialsEnv, "")
+		exchange := tokenEndpoint(t, http.StatusForbidden)
+		defer exchange.Close()
+		meta := metadataServer(t)
+		defer meta.Close()
+
+		p, err := New(WithServiceAccountJSON(serviceAccountJSON(t, exchange.URL)))
+		require.NoError(t, err)
+		p.Metadata = Metadata{Host: meta.URL}
+		got, err := p.Provide(ctx, "sigstore")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "metadata-sa@example.iam.gserviceaccount.com", got.Subject)
+	})
+
+	t.Run("service account failure without fallback errors", func(t *testing.T) {
+		t.Setenv(credentialsEnv, "")
+		exchange := tokenEndpoint(t, http.StatusForbidden)
+		defer exchange.Close()
+		meta := metadataServer(t)
+		defer meta.Close()
+
+		p, err := New(
+			WithServiceAccountJSON(serviceAccountJSON(t, exchange.URL)),
+			WithAmbientCredentials(false),
+		)
+		require.NoError(t, err)
+		p.Metadata = Metadata{Host: meta.URL}
+		_, err = p.Provide(ctx, "sigstore")
+		require.ErrorContains(t, err, "403")
+	})
+
+	t.Run("service account failure with no metadata surfaces the exchange error", func(t *testing.T) {
+		t.Setenv(credentialsEnv, "")
+		exchange := tokenEndpoint(t, http.StatusForbidden)
+		defer exchange.Close()
+
+		p, err := New(WithServiceAccountJSON(serviceAccountJSON(t, exchange.URL)))
+		require.NoError(t, err)
+		p.Metadata = deadMetadata(t)
+		_, err = p.Provide(ctx, "sigstore")
+		require.ErrorContains(t, err, "403")
+	})
+
+	t.Run("env var service account is used", func(t *testing.T) {
+		srv := tokenEndpoint(t, http.StatusOK)
+		defer srv.Close()
+		path := filepath.Join(t.TempDir(), "key.json")
+		require.NoError(t, os.WriteFile(path, serviceAccountJSON(t, srv.URL), 0o600))
+		t.Setenv(credentialsEnv, path)
+
+		p := &Provider{Metadata: deadMetadata(t)}
+		got, err := p.Provide(ctx, "sigstore")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, testEmail, got.Subject)
+	})
+
+	t.Run("explicit key wins over env var", func(t *testing.T) {
+		srv := tokenEndpoint(t, http.StatusOK)
+		defer srv.Close()
+		t.Setenv(credentialsEnv, filepath.Join(t.TempDir(), "missing.json"))
+
+		p, err := New(WithServiceAccountJSON(serviceAccountJSON(t, srv.URL)))
+		require.NoError(t, err)
+		got, err := p.Provide(ctx, "sigstore")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+	})
+
+	t.Run("unsupported env credential type falls through silently", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "wif.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"type":"external_account"}`), 0o600))
+		t.Setenv(credentialsEnv, path)
+		meta := metadataServer(t)
+		defer meta.Close()
+
+		p := &Provider{Metadata: Metadata{Host: meta.URL}}
+		got, err := p.Provide(ctx, "sigstore")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "metadata-sa@example.iam.gserviceaccount.com", got.Subject)
+	})
+
+	t.Run("broken env credential with no metadata errors", func(t *testing.T) {
+		t.Setenv(credentialsEnv, filepath.Join(t.TempDir(), "missing.json"))
+		p := &Provider{Metadata: deadMetadata(t)}
+		_, err := p.Provide(ctx, "sigstore")
+		require.ErrorContains(t, err, credentialsEnv)
+	})
+
+	t.Run("zero value off gcp reports no token", func(t *testing.T) {
+		t.Setenv(credentialsEnv, "")
+		p := &Provider{Metadata: deadMetadata(t)}
+		got, err := p.Provide(ctx, "sigstore")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("ambient disabled with no key is an error", func(t *testing.T) {
+		t.Setenv(credentialsEnv, "")
+		p, err := New(WithAmbientCredentials(false))
+		require.NoError(t, err)
+		_, err = p.Provide(ctx, "sigstore")
+		require.ErrorContains(t, err, "no service account key")
+	})
+}
+
+func TestNewOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid json is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(WithServiceAccountJSON([]byte("not json")))
+		require.Error(t, err)
+	})
+
+	t.Run("non service account credential is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(WithServiceAccountJSON([]byte(`{"type":"authorized_user"}`)))
+		require.ErrorContains(t, err, "not a service account")
+	})
+
+	t.Run("missing key file is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(WithServiceAccountFile(filepath.Join(t.TempDir(), "nope.json")))
+		require.Error(t, err)
+	})
+
+	t.Run("key file loads", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "key.json")
+		require.NoError(t, os.WriteFile(path, serviceAccountJSON(t, "https://example.com/token"), 0o600))
+		p, err := New(WithServiceAccountFile(path))
+		require.NoError(t, err)
+		require.NotNil(t, p)
+	})
+}

--- a/sts/providers/gcp/serviceaccount.go
+++ b/sts/providers/gcp/serviceaccount.go
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+)
+
+const (
+	// credentialsEnv is Google's standard application-default-credentials
+	// variable. When no key is configured explicitly the provider reads the
+	// key file it names, mirroring ADC precedence.
+	credentialsEnv = "GOOGLE_APPLICATION_CREDENTIALS" //nolint:gosec // G101: env variable name, not a credential
+
+	// serviceAccountType is the only ADC credential type this provider can
+	// exchange. The other types (authorized_user, external_account) cannot
+	// mint arbitrary-audience identity tokens from a self-signed assertion.
+	serviceAccountType = "service_account"
+
+	// defaultTokenURI is used when the key file omits token_uri.
+	defaultTokenURI = "https://oauth2.googleapis.com/token" //nolint:gosec // G101: public endpoint URL, not a credential
+
+	// jwtBearerGrant is the RFC 7523 grant type for the assertion exchange.
+	jwtBearerGrant = "urn:ietf:params:oauth:grant-type:jwt-bearer" //nolint:gosec // G101: RFC 7523 grant type URN, not a credential
+
+	// exchangeTimeout bounds the call to the OAuth token endpoint. Unlike the
+	// metadata probe this is a real internet round trip, so it gets more room
+	// than defaultTimeout.
+	exchangeTimeout = 10 * time.Second
+
+	// assertionLifetime is the validity window of the self-signed assertion.
+	// It only needs to outlive the exchange request.
+	assertionLifetime = 5 * time.Minute
+
+	// assertionSkew is subtracted from the assertion's iat so a slightly
+	// fast local clock does not make Google reject it as not yet valid.
+	assertionSkew = 10 * time.Second
+)
+
+// serviceAccount is a parsed Google service-account key file.
+type serviceAccount struct {
+	Type         string `json:"type"`
+	ClientEmail  string `json:"client_email"`
+	PrivateKeyID string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"`
+	TokenURI     string `json:"token_uri"`
+
+	key *rsa.PrivateKey
+}
+
+// parseServiceAccount parses and validates a service-account JSON key,
+// including its private key, so misconfiguration surfaces at option time
+// rather than on the first signing.
+func parseServiceAccount(data []byte) (*serviceAccount, error) {
+	sa := &serviceAccount{}
+	if err := json.Unmarshal(data, sa); err != nil {
+		return nil, fmt.Errorf("parsing service account JSON: %w", err)
+	}
+	if sa.Type != serviceAccountType {
+		return nil, fmt.Errorf("credential type %q is not a service account key", sa.Type)
+	}
+	if sa.ClientEmail == "" {
+		return nil, errors.New("service account key has no client_email")
+	}
+	if sa.TokenURI == "" {
+		sa.TokenURI = defaultTokenURI
+	}
+	block, _ := pem.Decode([]byte(sa.PrivateKey))
+	if block == nil {
+		return nil, errors.New("service account key has no PEM-encoded private key")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing service account private key: %w", err)
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("service account private key is %T, expected RSA", parsed)
+	}
+	sa.key = rsaKey
+	return sa, nil
+}
+
+// provide mints an OIDC identity token for the audience by signing a
+// JWT-bearer assertion with the service-account key and exchanging it at the
+// key's token endpoint. This is the same flow Google's idtoken package runs,
+// implemented on the standard library to keep the package dependency-light.
+func (sa *serviceAccount) provide(ctx context.Context, audience string) (*oauthflow.OIDCIDToken, error) {
+	audience, err := validateAudience(audience)
+	if err != nil {
+		return nil, err
+	}
+
+	assertion, err := sa.signAssertion(audience, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	form := url.Values{
+		"grant_type": []string{jwtBearerGrant},
+		"assertion":  []string{assertion},
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, sa.TokenURI, strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: exchangeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("exchanging service account assertion: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	// Cap the read: the endpoint returns a small JSON document and error
+	// bodies only get quoted in the message below.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading token endpoint response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"token endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)),
+		)
+	}
+
+	token := struct {
+		IDToken string `json:"id_token"`
+	}{}
+	if err := json.Unmarshal(body, &token); err != nil {
+		return nil, fmt.Errorf("parsing token endpoint response: %w", err)
+	}
+	if token.IDToken == "" {
+		return nil, errors.New("token endpoint response has no id_token")
+	}
+
+	subject, err := subjectFromJWT(token.IDToken)
+	if err != nil {
+		return nil, fmt.Errorf("extracting subject from identity token: %w", err)
+	}
+	return &oauthflow.OIDCIDToken{RawString: token.IDToken, Subject: subject}, nil
+}
+
+// signAssertion builds and signs the RS256 JWT-bearer assertion whose
+// target_audience claim asks Google for an identity token with that audience.
+func (sa *serviceAccount) signAssertion(audience string, now time.Time) (string, error) {
+	header, err := json.Marshal(map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": sa.PrivateKeyID,
+	})
+	if err != nil {
+		return "", err
+	}
+	claims, err := json.Marshal(struct {
+		Issuer         string `json:"iss"`
+		Subject        string `json:"sub"`
+		Audience       string `json:"aud"`
+		IssuedAt       int64  `json:"iat"`
+		Expiry         int64  `json:"exp"`
+		TargetAudience string `json:"target_audience"`
+	}{
+		Issuer:         sa.ClientEmail,
+		Subject:        sa.ClientEmail,
+		Audience:       sa.TokenURI,
+		IssuedAt:       now.Add(-assertionSkew).Unix(),
+		Expiry:         now.Add(assertionLifetime).Unix(),
+		TargetAudience: audience,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	signingInput := base64.RawURLEncoding.EncodeToString(header) +
+		"." + base64.RawURLEncoding.EncodeToString(claims)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, sa.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("signing assertion: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}

--- a/sts/sts.go
+++ b/sts/sts.go
@@ -19,17 +19,19 @@ var (
 	_ Provider = &github.Actions{}
 	_ Provider = &gitlab.CI{}
 	_ Provider = &gcp.Metadata{}
+	_ Provider = &gcp.Provider{}
 )
 
 // These are the default STS providers, the signer project has additional
 // providers in https://github.com/carabiner-dev/signer-extras which have a
-// heavier dependency footprint. gcp reads the service-account identity token
-// from the Google Cloud metadata server and, like the others, reports no token
-// when its environment is absent.
+// heavier dependency footprint. gcp mints a service-account identity token
+// from $GOOGLE_APPLICATION_CREDENTIALS or the Google Cloud metadata server
+// and, like the others, reports no token when its environment is absent.
+// Build it with gcp.New to pin a service account key explicitly.
 var DefaultProviders = map[string]Provider{
 	"gitlab":  &gitlab.CI{},
 	"actions": &github.Actions{},
-	"gcp":     &gcp.Metadata{},
+	"gcp":     &gcp.Provider{},
 }
 
 var mtx sync.Mutex


### PR DESCRIPTION
This PR improves the GCP STS provider adding support for application default credentials and support for identities generated from service account tokens.