### PR TITLE
Improve concurrency support

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
@@ -49,8 +50,8 @@ type Backend interface {
 }
 
 // bundleBackendBase carries the shared state and signing helpers used
-// by sigstoreBackend and spiffeBackend — both produce sigstore
-// bundles from a bundle.CredentialProvider. It is embedded by both;
+// by both sigstoreBackend and spiffeBackend. Both produce sigstore
+// bundles from a bundle.CredentialProvider. It is embedded by both
 // the per-backend prepare logic (auto-build creds for sigstore, require
 // pre-set creds for spiffe) lives on the wrapping types.
 type bundleBackendBase struct {
@@ -58,6 +59,10 @@ type bundleBackendBase struct {
 	creds        bundle.CredentialProvider
 	bundleSigner bundle.Signer
 
+	// mu guards the lazy preparation state (ready, creds, bundleOpts).
+	// prepare errors are not cached: ready is only set on success, so
+	// later sign calls retry after a transient failure.
+	mu         sync.Mutex
 	ready      bool
 	bundleOpts *sign.BundleOptions
 }
@@ -119,9 +124,12 @@ func (b *sigstoreBackend) SignMessage(data []byte, _ ...options.SignOptFn) (Sign
 }
 
 // prepare builds (lazily, once) the sigstore credentials + bundle
-// options. Auto-builds creds from Options when not pre-set — that's
-// the sigstore-specific behavior.
+// options. Auto-builds creds from Options when not pre-set (a
+// sigstore-specific behavior). Safe for concurrent use.
 func (b *sigstoreBackend) prepare() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	if b.ready {
 		return nil
 	}
@@ -190,9 +198,12 @@ func (b *spiffeBackend) SignMessage(data []byte, _ ...options.SignOptFn) (Signed
 }
 
 // prepare prepares the SVID and computes bundle options. Unlike
-// sigstoreBackend.prepare, this does not auto-build creds — the
-// constructor enforces a non-nil creds value.
+// sigstoreBackend.prepare, this does not auto-build creds: the
+// constructor enforces a non-nil creds value. Safe for concurrent use.
 func (b *spiffeBackend) prepare() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	if b.ready {
 		return nil
 	}

--- a/signer.go
+++ b/signer.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	sdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	sbundle "github.com/sigstore/sigstore-go/pkg/bundle"
@@ -85,6 +86,13 @@ func NewSigner() *Signer {
 // concrete Backend that does the actual signing on each call. The
 // signing logic lives entirely in the Backend implementations
 // (sigstoreBackend / spiffeBackend / keyBackend in backend.go).
+//
+// A Signer instance is safe for concurrent use by multiple goroutines
+// once constructed: the lazy backend/credential initialization and the
+// Fulcio certificate cache are internally synchronized.
+//
+// Important: Options and Credentials must not be mutated after the
+// first sign call.
 type Signer struct {
 	Options options.Signer
 
@@ -103,9 +111,12 @@ type Signer struct {
 
 	// persistent caches the resolved Backend across calls so the OIDC
 	// flow + Fulcio cert request happen once, not per call. Built
-	// lazily on first sign call. Per-call options.WithKey produces a
-	// transient keyBackend that does NOT replace this cache.
+	// lazily on first sign call under mu. Per-call options.WithKey
+	// produces a transient keyBackend that does NOT replace this cache.
 	persistent Backend
+
+	// mu guards the lazy construction of persistent.
+	mu sync.Mutex
 }
 
 // SignStatement signs an in-toto attestation and returns a polymorphic
@@ -156,8 +167,12 @@ func (s *Signer) resolveBackend(funcs []options.SignOptFn) (Backend, error) {
 }
 
 // persistentBackend returns the cached persistent backend, building it
-// on first call from Signer.Options.Backend.
+// on first call from Signer.Options.Backend. Safe for concurrent use;
+// construction errors are not cached, so later calls retry.
 func (s *Signer) persistentBackend() (Backend, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.persistent != nil {
 		return s.persistent, nil
 	}

--- a/signer_race_test.go
+++ b/signer_race_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Concurrency regression tests. Run with -race: they exercise the lazy
+// persistent-backend construction and the sigstore backend preparation
+// from many goroutines at once.
+
+const raceTestStatement = `{
+  "predicateType": "https://example.com/my-predicate/v1",
+  "predicate": { "something": "custom" },
+  "type": "https://in-toto.io/Statement/v0.1",
+  "subject": [
+    { "name": "MY-POLICY" }
+  ]
+}
+`
+
+func TestSignStatementBundleConcurrent(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness()
+	sut := h.signer(t)
+
+	const workers = 32
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = sut.SignStatementBundle([]byte(raceTestStatement))
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "worker %d", i)
+	}
+
+	// Preparation must have run exactly once across all workers.
+	require.Equal(t, 1, h.credentials.PrepareCallCount())
+	require.Equal(t, 1, h.bundleSigner.BuildBundleOptionsCallCount())
+	require.Equal(t, workers, h.bundleSigner.SignBundleCallCount())
+}
+
+func TestSignStatementBundleConcurrentPrepareRetry(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness()
+	// The first preparation attempt fails; the error must not be cached,
+	// so exactly one worker errors out and the rest retry and succeed.
+	h.credentials.PrepareReturnsOnCall(0, errors.New("transient failure"))
+	sut := h.signer(t)
+
+	const workers = 16
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = sut.SignStatementBundle([]byte(raceTestStatement))
+		}()
+	}
+	wg.Wait()
+
+	failures := 0
+	for _, err := range errs {
+		if err != nil {
+			failures++
+		}
+	}
+
+	require.Equal(t, 1, failures, "only the worker that hit the transient failure should error")
+	require.Equal(t, 2, h.credentials.PrepareCallCount(), "prepare should retry once after the failure")
+}

--- a/sigstore/caching_cert_provider_race_test.go
+++ b/sigstore/caching_cert_provider_race_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCertProvider implements sign.CertificateProvider, issuing a fresh
+// leaf from the fake CA on every call and counting how often it is hit. With
+// expired set, the issued certificates are already outside their validity
+// window, forcing the caching wrapper down the refresh path on every call.
+type countingCertProvider struct {
+	ca      *fakeCA
+	expired bool
+	calls   atomic.Int32
+}
+
+func (c *countingCertProvider) GetCertificate(_ context.Context, kp sign.Keypair, _ *sign.CertificateProviderOptions) ([]byte, error) {
+	c.calls.Add(1)
+
+	notBefore, notAfter := time.Now().Add(-time.Minute), time.Now().Add(10*time.Minute)
+	if c.expired {
+		notBefore, notAfter = time.Now().Add(-time.Hour), time.Now().Add(-time.Minute)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(4),
+		Subject:      pkix.Name{CommonName: "signer@example.com"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+	}
+
+	return x509.CreateCertificate(rand.Reader, tmpl, c.ca.interCert, kp.GetPublicKey(), c.ca.interKey)
+}
+
+// TestCachingCertProviderConcurrent hammers the cache with a valid
+// certificate: exactly one Fulcio request should be made and every caller
+// must observe the same certificate. Run with -race.
+func TestCachingCertProviderConcurrent(t *testing.T) {
+	t.Parallel()
+
+	inner := &countingCertProvider{ca: newFakeCA(t)}
+	cache := &cachingCertProvider{inner: inner}
+
+	kp, err := sign.NewEphemeralKeypair(nil)
+	require.NoError(t, err)
+
+	const workers = 32
+	certs := make([][]byte, workers)
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			certs[i], errs[i] = cache.GetCertificate(context.Background(), kp, nil)
+		}()
+	}
+	wg.Wait()
+
+	for i := range workers {
+		require.NoError(t, errs[i], "worker %d", i)
+		require.Equal(t, certs[0], certs[i], "worker %d got a different certificate", i)
+	}
+
+	require.Equal(t, int32(1), inner.calls.Load(), "concurrent signs should share one certificate request")
+}
+
+// TestCachingCertProviderConcurrentRefresh drives the cache with
+// certificates that are already expired, so every call takes the refresh
+// path under contention. The point is the -race run: refreshes must not
+// tear the cached certificate/validity fields.
+func TestCachingCertProviderConcurrentRefresh(t *testing.T) {
+	t.Parallel()
+
+	inner := &countingCertProvider{ca: newFakeCA(t), expired: true}
+	cache := &cachingCertProvider{inner: inner}
+
+	kp, err := sign.NewEphemeralKeypair(nil)
+	require.NoError(t, err)
+
+	const workers = 16
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = cache.GetCertificate(context.Background(), kp, nil)
+		}()
+	}
+	wg.Wait()
+
+	for i := range workers {
+		require.NoError(t, errs[i], "worker %d", i)
+	}
+
+	require.Equal(t, int32(workers), inner.calls.Load(), "expired certificates must not be served from the cache")
+}

--- a/sigstore/credential_provider.go
+++ b/sigstore/credential_provider.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sigstore/sigstore-go/pkg/root"
@@ -40,8 +41,15 @@ type CredentialProvider struct {
 	// Token is an optional pre-provided OIDC ID token. When set, Prepare skips
 	// the ambient STS providers; the token still flows through OIDConnect so
 	// that it is parsed/validated the same way as a freshly issued one.
+	// Treated as read-only input: Prepare stores the parsed result in the
+	// private token field instead of writing back here.
 	Token *oauthflow.OIDCIDToken
 
+	// mu guards the lazy preparation state below. Prepare errors are not
+	// cached: prepared is only set on success, so later calls retry after
+	// a transient failure.
+	mu          sync.Mutex
+	token       *oauthflow.OIDCIDToken
 	keypair     *sign.EphemeralKeypair
 	cp          sign.CertificateProvider
 	trustedRoot *root.TrustedRoot
@@ -55,8 +63,11 @@ func NewCredentialProvider(instance *Instance) *CredentialProvider {
 
 // Prepare runs the OIDC flow, ensures TUF roots are on disk, generates an
 // ephemeral keypair, and builds the Fulcio certificate provider. Subsequent
-// calls are no-ops.
+// calls are no-ops. Safe for concurrent use.
 func (p *CredentialProvider) Prepare(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.prepared {
 		return nil
 	}
@@ -84,17 +95,20 @@ func (p *CredentialProvider) Prepare(ctx context.Context) error {
 	p.keypair = kp
 
 	// Try ambient STS providers before falling back to an interactive flow.
-	if !p.DisableSTS && p.Token == nil {
-		if err := p.runAmbientSTS(ctx); err != nil {
+	seed := p.Token
+	if !p.DisableSTS && seed == nil {
+		ambient, err := p.runAmbientSTS(ctx)
+		if err != nil {
 			return fmt.Errorf("fetching ambient credentials: %w", err)
 		}
+		seed = ambient
 	}
 
-	tok, err := p.runOIDCFlow()
+	tok, err := p.runOIDCFlow(seed)
 	if err != nil {
 		return fmt.Errorf("getting ID token: %w", err)
 	}
-	p.Token = tok
+	p.token = tok
 
 	fulcioURL := p.Instance.FulcioURL()
 	if fulcioURL == "" {
@@ -116,14 +130,28 @@ func (p *CredentialProvider) Prepare(ctx context.Context) error {
 }
 
 // Keypair returns the ephemeral keypair bound to the Fulcio certificate.
-func (p *CredentialProvider) Keypair() sign.Keypair { return p.keypair }
+func (p *CredentialProvider) Keypair() sign.Keypair {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.keypair
+}
 
 // CertificateProvider returns the Fulcio provider and the OIDC ID token that
-// authenticates the signing cert request.
+// authenticates the signing cert request. The token parsed during Prepare
+// wins; the public Token field is the fallback for providers assembled by
+// hand that never went through Prepare.
 func (p *CredentialProvider) CertificateProvider() (sign.CertificateProvider, *sign.CertificateProviderOptions) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	tok := p.token
+	if tok == nil {
+		tok = p.Token
+	}
+
 	var opts *sign.CertificateProviderOptions
-	if p.Token != nil {
-		opts = &sign.CertificateProviderOptions{IDToken: p.Token.RawString}
+	if tok != nil {
+		opts = &sign.CertificateProviderOptions{IDToken: tok.RawString}
 	}
 	return p.cp, opts
 }
@@ -265,32 +293,32 @@ func isSelfSigned(cert *x509.Certificate) bool {
 	return bytes.Equal(cert.RawIssuer, cert.RawSubject)
 }
 
-// runAmbientSTS iterates over the configured STS providers until it gets a token
-func (p *CredentialProvider) runAmbientSTS(ctx context.Context) error {
-	for k, provider := range sts.DefaultProviders {
+// runAmbientSTS iterates over the configured STS providers and returns the
+// first token one of them yields, or nil when no provider has credentials.
+func (p *CredentialProvider) runAmbientSTS(ctx context.Context) (*oauthflow.OIDCIDToken, error) {
+	for k, provider := range sts.Providers() {
 		token, err := provider.Provide(ctx, p.Instance.OIDCConfig.ClientID)
 		if err != nil {
-			return fmt.Errorf("trying ambien credentials from %s: %w", k, err)
+			return nil, fmt.Errorf("trying ambient credentials from %s: %w", k, err)
 		}
 		if token != nil {
-			p.Token = token
-			return nil
+			return token, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // runOIDCFlow does the OIDC exchange to get the token.
-// If a token is already set it goes through the static flow which just
+// If a seed token is provided it goes through the static flow which just
 // parses and returns it unchanged. Otherwise the flow is chosen based on the
 // environment (browser, device flow, or fail-fast in CI).
-func (p *CredentialProvider) runOIDCFlow() (*oauthflow.OIDCIDToken, error) {
+func (p *CredentialProvider) runOIDCFlow(seed *oauthflow.OIDCIDToken) (*oauthflow.OIDCIDToken, error) {
 	issuer := p.Instance.OidcIssuerURL()
 
 	var flow oauthflow.TokenGetter
 	switch {
-	case p.Token != nil:
-		flow = &oauthflow.StaticTokenGetter{RawToken: p.Token.RawString}
+	case seed != nil:
+		flow = &oauthflow.StaticTokenGetter{RawToken: seed.RawString}
 	case !term.IsTerminal(0):
 		if os.Getenv("CI") != "" {
 			return nil, fmt.Errorf(
@@ -333,7 +361,12 @@ func randomizePort(redirectURL string) string {
 // cachingCertProvider wraps a CertificateProvider and caches the certificate
 // within its validity window. This avoids issuing multiple Fulcio certificate
 // requests when the same keypair is used to sign several artifacts.
+//
+// The mutex spans the whole check-fetch-store sequence, which doubles as
+// singleflight: when the cached certificate expires mid-run, one caller
+// refreshes it while concurrent signs wait instead of stampeding Fulcio.
 type cachingCertProvider struct {
+	mu        sync.Mutex
 	inner     sign.CertificateProvider
 	cert      []byte
 	notBefore time.Time
@@ -341,6 +374,9 @@ type cachingCertProvider struct {
 }
 
 func (c *cachingCertProvider) GetCertificate(ctx context.Context, kp sign.Keypair, opts *sign.CertificateProviderOptions) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	now := time.Now()
 	if c.cert != nil && now.After(c.notBefore) && now.Before(c.notAfter) {
 		return c.cert, nil

--- a/sigstore/credential_provider_test.go
+++ b/sigstore/credential_provider_test.go
@@ -17,7 +17,7 @@ func TestRunOIDCFlowFailsInCI(t *testing.T) {
 
 	t.Setenv("CI", "true")
 
-	_, err := cp.runOIDCFlow()
+	_, err := cp.runOIDCFlow(nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no OIDC ambient credentials found in CI environment")
 }

--- a/sts/sts.go
+++ b/sts/sts.go
@@ -28,13 +28,29 @@ var (
 // from $GOOGLE_APPLICATION_CREDENTIALS or the Google Cloud metadata server
 // and, like the others, reports no token when its environment is absent.
 // Build it with gcp.New to pin a service account key explicitly.
+//
+// Access the map through Providers/RegisterProvider/UnregisterProvider:
+// iterating it directly is not synchronized with concurrent registration.
 var DefaultProviders = map[string]Provider{
 	"gitlab":  &gitlab.CI{},
 	"actions": &github.Actions{},
 	"gcp":     &gcp.Provider{},
 }
 
-var mtx sync.Mutex
+var mtx sync.RWMutex
+
+// Providers returns a snapshot of the registered STS providers, safe to
+// iterate while other goroutines register or unregister providers.
+func Providers() map[string]Provider {
+	mtx.RLock()
+	defer mtx.RUnlock()
+
+	snapshot := make(map[string]Provider, len(DefaultProviders))
+	for k, p := range DefaultProviders {
+		snapshot[k] = p
+	}
+	return snapshot
+}
 
 // RegisterProvider registers a new provider
 func RegisterProvider(key string, p Provider) {
@@ -43,8 +59,8 @@ func RegisterProvider(key string, p Provider) {
 	mtx.Unlock()
 }
 
-// RegisterProvider registers a new provider
-func UnregisterProvider(key string, p Provider) {
+// UnregisterProvider removes a registered provider
+func UnregisterProvider(key string, _ Provider) {
 	mtx.Lock()
 	delete(DefaultProviders, key)
 	mtx.Unlock()


### PR DESCRIPTION
This commit adds mutexes mostly to the initialization of the signer, the sigstore backend and the STS registry to ensure the signer is safe to use in concurrent goroutines.

We've also added some tests to check races in the components init functions.